### PR TITLE
BugFix: WebMvcTest+ SpringSecurity Configuration

### DIFF
--- a/animory/src/test/java/com/daggle/animory/shortform/ShortFormControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/shortform/ShortFormControllerTest.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.shortform;
 
+import com.daggle.animory.common.config.SpringSecurityConfiguration;
 import com.daggle.animory.model.Province;
 import com.daggle.animory.model.pet.PetType;
 import org.junit.jupiter.api.Nested;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -17,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest
 @AutoConfigureMockMvc
+@Import(SpringSecurityConfiguration.class) // TODO: Base Test Class 상속하는 방식으로..
 class ShortFormControllerTest {
     @Autowired
     private MockMvc mvc;


### PR DESCRIPTION
## 작업 내용
- WebMvcTest 가 SpringSecurityConfiguration을 사용하지 않아서 테스트가 실패하는 문제 해결


Close #41 