### PR TITLE
시큐리티 설정

### DIFF
--- a/animory/build.gradle
+++ b/animory/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.security:spring-security-test'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
 	// db
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/animory/files_upload_location/20230928103040_test1.mp4
+++ b/animory/files_upload_location/20230928103040_test1.mp4
@@ -1,1 +1,0 @@
-test file1

--- a/animory/files_upload_location/20230928103040_test2.jpeg
+++ b/animory/files_upload_location/20230928103040_test2.jpeg
@@ -1,1 +1,0 @@
-test file2

--- a/animory/files_upload_location/20230930055151_test1.mp4
+++ b/animory/files_upload_location/20230930055151_test1.mp4
@@ -1,1 +1,0 @@
-test file1

--- a/animory/files_upload_location/20230930055151_test2.jpeg
+++ b/animory/files_upload_location/20230930055151_test2.jpeg
@@ -1,1 +1,0 @@
-test file2

--- a/animory/files_upload_location/20230930071506_test1.mp4
+++ b/animory/files_upload_location/20230930071506_test1.mp4
@@ -1,1 +1,0 @@
-test file1

--- a/animory/files_upload_location/20230930071506_test2.jpeg
+++ b/animory/files_upload_location/20230930071506_test2.jpeg
@@ -1,1 +1,0 @@
-test file2

--- a/animory/src/main/java/com/daggle/animory/common/FilterResponseUtils.java
+++ b/animory/src/main/java/com/daggle/animory/common/FilterResponseUtils.java
@@ -1,0 +1,26 @@
+package com.daggle.animory.common;
+
+import com.daggle.animory.common.error.exception.Forbidden403;
+import com.daggle.animory.common.error.exception.UnAuthorized401;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class FilterResponseUtils {
+    public static void unAuthorized(HttpServletResponse resp, UnAuthorized401 e) throws IOException {
+        resp.setStatus(e.status().value());
+        resp.setContentType("application/json; charset=utf-8");
+        ObjectMapper om = new ObjectMapper();
+        String responseBody = om.writeValueAsString(e.body());
+        resp.getWriter().println(responseBody);
+    }
+
+    public static void forbidden(HttpServletResponse resp, Forbidden403 e) throws IOException {
+        resp.setStatus(e.status().value());
+        resp.setContentType("application/json; charset=utf-8");
+        ObjectMapper om = new ObjectMapper();
+        String responseBody = om.writeValueAsString(e.body());
+        resp.getWriter().println(responseBody);
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/common/config/SpringSecurityConfiguration.java
+++ b/animory/src/main/java/com/daggle/animory/common/config/SpringSecurityConfiguration.java
@@ -3,7 +3,7 @@ package com.daggle.animory.common.config;
 import com.daggle.animory.common.FilterResponseUtils;
 import com.daggle.animory.common.error.exception.Forbidden403;
 import com.daggle.animory.common.error.exception.UnAuthorized401;
-import com.daggle.animory.common.security.JwtTokenFilter;
+import com.daggle.animory.common.security.TokenFilter;
 import com.daggle.animory.common.security.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -38,7 +38,7 @@ public class SpringSecurityConfiguration {
 
                 // 커스텀 필터 적용
                 .and()
-                .addFilterBefore(new JwtTokenFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new TokenFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
 
                 // 인증 실패 처리
                 .exceptionHandling().authenticationEntryPoint((request, response, authException) -> {

--- a/animory/src/main/java/com/daggle/animory/common/config/SpringSecurityConfiguration.java
+++ b/animory/src/main/java/com/daggle/animory/common/config/SpringSecurityConfiguration.java
@@ -54,8 +54,8 @@ public class SpringSecurityConfiguration {
                 // Endpoint 인증/인가 필터 설정
                 .and()
                 .authorizeRequests()
-                .antMatchers(HttpMethod.POST, "/shelter/**", "/pet/**").access("hasRole(ROLE_SHELTER)")
-                .antMatchers(HttpMethod.PATCH, "/pet/**").access("hasRole(ROLE_SHELTER)")
+                .antMatchers(HttpMethod.POST, "/shelter/**", "/pet/**").access("hasRole('ROLE_SHELTER')")
+                .antMatchers(HttpMethod.PATCH, "/pet/**").access("hasRole('ROLE_SHELTER')")
                 .anyRequest().permitAll();
 
         return http.build();

--- a/animory/src/main/java/com/daggle/animory/common/config/SpringSecurityConfiguration.java
+++ b/animory/src/main/java/com/daggle/animory/common/config/SpringSecurityConfiguration.java
@@ -1,29 +1,62 @@
 package com.daggle.animory.common.config;
 
+import com.daggle.animory.common.FilterResponseUtils;
+import com.daggle.animory.common.error.exception.Forbidden403;
+import com.daggle.animory.common.error.exception.UnAuthorized401;
+import com.daggle.animory.common.security.JwtTokenFilter;
+import com.daggle.animory.common.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
+@EnableWebSecurity // 시큐리티 필터(SpringSecurityConfiguration)가 필터체인에 등록
+@RequiredArgsConstructor
 public class SpringSecurityConfiguration {
+    private final TokenProvider tokenProvider;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        // CSRF 해제
-        http.csrf().disable();
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        // cors 재설정
-        http.cors().configurationSource(configurationSource());
+        http.csrf().disable() // csrf 해제
+                .formLogin().disable()// form 로그인 비활성화
+                .cors().configurationSource(configurationSource()) // cors 재설정
 
-        // Endpoint 인증/인가 필터 설정
-        http.authorizeRequests(
-            authorize -> authorize
-                .anyRequest().permitAll()
-        );
+                // jwt 사용
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                // 커스텀 필터 적용
+                .and()
+                .addFilterBefore(new JwtTokenFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+
+                // 인증 실패 처리
+                .exceptionHandling().authenticationEntryPoint((request, response, authException) -> {
+                    FilterResponseUtils.unAuthorized(response, new UnAuthorized401("인증되지 않았습니다"));
+                })
+
+                // 권한 실패 처리
+                .and()
+                .exceptionHandling().accessDeniedHandler((request, response, accessDeniedException) -> {
+                    FilterResponseUtils.forbidden(response, new Forbidden403("권한이 없습니다"));
+                })
+
+                // Endpoint 인증/인가 필터 설정
+                .and()
+                .authorizeRequests()
+                .antMatchers(HttpMethod.POST, "/shelter/**", "/pet/**").access("hasRole(ROLE_SHELTER)")
+                .antMatchers(HttpMethod.PATCH, "/pet/**").access("hasRole(ROLE_SHELTER)")
+                .anyRequest().permitAll();
 
         return http.build();
     }

--- a/animory/src/main/java/com/daggle/animory/common/security/TokenFilter.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/TokenFilter.java
@@ -1,0 +1,30 @@
+package com.daggle.animory.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class TokenFilter extends GenericFilterBean {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String token = tokenProvider.resolveToken((HttpServletRequest) request);
+
+        // 유효한 토큰인지 확인
+        if (token != null && tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
@@ -66,7 +67,12 @@ public class TokenProvider {
 
     // 헤더에서 token 추출
     public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("Authorization");
+        String bearerToken = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 
     // 토큰의 유효 확인

--- a/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
@@ -1,0 +1,81 @@
+package com.daggle.animory.common.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    @Value("${jwt.secret}")
+    private String key;
+
+    @Value("${jwt.token-validity-in-seconds}")
+    private long tokenValiditySeconds;
+
+    private final UserDetailsService userDetailsService;
+    public static final String TOKEN_PREFIX = "Bearer ";
+    private static final String AUTHORITIES_KEY = "auth";
+
+
+    // secretKey를 Base64로 인코딩
+    @PostConstruct
+    public void init() throws Exception {
+        this.key = Base64.getEncoder().encodeToString(key.getBytes());
+    }
+
+    public String create(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Date now = new Date();
+
+        return TOKEN_PREFIX + Jwts.builder()
+                .setSubject(authentication.getName()) // 정보 저장
+                .claim(AUTHORITIES_KEY, authorities)
+                .setIssuedAt(new Date()) // 토큰 발행 시간
+                .setExpiration(new Date(now.getTime() + tokenValiditySeconds)) // 토큰 만료 시간
+                .signWith(SignatureAlgorithm.HS256, key)  // 암호화 알고리즘 및 secretKey
+                .compact();
+    }
+
+    // 인증 정보 조회
+    public Authentication getAuthentication(String token) {
+        String accountSubject = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody().getSubject();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(accountSubject);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    // 헤더에서 token 추출
+    public String resolveToken(HttpServletRequest request) {
+        return request.getHeader("Authorization");
+    }
+
+    // 토큰의 유효 확인
+    public boolean validateToken(String jwtToken) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(key).parseClaimsJws(jwtToken);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/common/security/UserDetailsImpl.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/UserDetailsImpl.java
@@ -1,0 +1,57 @@
+package com.daggle.animory.common.security;
+
+import com.daggle.animory.domain.account.Account;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+@RequiredArgsConstructor
+@Getter
+
+public class UserDetailsImpl implements UserDetails {
+    private Account account;
+
+    public UserDetailsImpl(Account account) {
+        this.account = account;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add((GrantedAuthority) () -> account.getRole().toString());
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return account.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return account.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/common/security/UserDetailsServiceImpl.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/UserDetailsServiceImpl.java
@@ -1,0 +1,18 @@
+package com.daggle.animory.common.security;
+
+import com.daggle.animory.domain.account.Account;
+import com.daggle.animory.domain.account.AccountRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private AccountRepository accountRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Account account = accountRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 사용자입니다."));
+        return new UserDetailsImpl(account);
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/domain/account/AccountRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/AccountRepository.java
@@ -1,0 +1,9 @@
+package com.daggle.animory.domain.account;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AccountRepository extends JpaRepository<Account, Integer> {
+    Optional<Account> findByEmail(String email);
+}

--- a/animory/src/main/resources/application.yml
+++ b/animory/src/main/resources/application.yml
@@ -40,4 +40,10 @@ springdoc.swagger-ui:
     path: /docs
     tags-sorter: alpha # 태그를 알파벳 순으로 정렬합니다.
 
+  # security
+jwt:
+  header: Authorization
+  secret: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK
+  token-validity-in-seconds: 86700
+
 

--- a/animory/src/test/java/com/daggle/animory/domain/pet/PetControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/pet/PetControllerTest.java
@@ -5,18 +5,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-
-import java.nio.charset.StandardCharsets;
 
 
 
 @AutoConfigureMockMvc
 @SpringBootTest
+@WithMockUser(roles = "SHELTER")
 class PetControllerTest {
     @Autowired
     private MockMvc mvc;

--- a/animory/src/test/java/com/daggle/animory/domain/shortform/ShortFormControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shortform/ShortFormControllerTest.java
@@ -1,8 +1,9 @@
 package com.daggle.animory.domain.shortform;
 
 import com.daggle.animory.common.config.SpringSecurityConfiguration;
-import com.daggle.animory.domain.shelter.Province;
+import com.daggle.animory.common.security.TokenProvider;
 import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.shelter.Province;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -17,9 +18,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest({ ShortFormController.class })
+@WebMvcTest({
+    SpringSecurityConfiguration.class,
+    TokenProvider.class
+})
 @AutoConfigureMockMvc
-@Import(SpringSecurityConfiguration.class) // TODO: Base Test Class 상속하는 방식으로..
+@Import(ShortFormController.class) // TODO: Base Test Class 상속하는 방식으로..
 class ShortFormControllerTest {
     @Autowired
     private MockMvc mvc;


### PR DESCRIPTION
## 작업 내용
- jwt 설정
- 커스텀 필터 적용
- 시큐리티 실패 처리
- Endpoint 인증/인가 필터 설정에 권한 추가
- 토큰 인증정보 조회를 위한 UserDetailsServiceImpl 생성 및 UserDetailsImpl 생성
- 토큰 생성 및 검증을 위한 TokenProvider 구현

## 논의하고 싶은 내용
- 리프레시 토큰의 도입 유무
  - 아직은 필요하지 않다고 생각하여 도입하지 않았는데 이 부분에 대해 향후 논의가 필요할 것 같습니다.

## 공유하고 싶은 내용
- 시큐리티 인증방식에는 여러가지가 있는데 이번에 다양한 종류에 대해 처음 알게 되었습니다...!
  - [참고한 블로그](https://velog.io/@wook2pp/%EC%8A%A4%ED%94%84%EB%A7%81-%EC%8B%9C%ED%81%90%EB%A6%AC%ED%8B%B0%EB%A5%BC-%ED%86%B5%ED%95%9C-%EC%9D%B8%EC%A6%9D%EC%B2%98%EB%A6%AC)

Close #45 