### PR TITLE
Java Code Coverage 측정 도구 도입 및 통합 프로세스에 추가

### DIFF
--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -48,6 +48,7 @@ jobs:
     
       - name: Add Jacoco Test coverage to PR
         uses: madrapps/jacoco-report@v1.6.1
+        token: ${{ secrets.GITHUB_TOKEN }}
         with:
           paths: |
             ${{ github.workspace }}/animory/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -47,10 +47,10 @@ jobs:
           report_paths: animory/build/test-results/test/TEST-*.xml
     
       - name: Add Jacoco Test coverage to PR
-        uses: madrapps/jacoco-report@v1.6.1
-        token: ${{ secrets.GITHUB_TOKEN }}
+        uses: madrapps/jacoco-report@v1.6.1        
         with:
           paths: |
             ${{ github.workspace }}/animory/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 50
           min-coverage-changed-files: 50

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -40,9 +40,16 @@ jobs:
         working-directory: ./animory
         run: ./gradlew test --warning-mode=all --stacktrace # stacktrace
 
-      - name: Publish Unit Test Results # test 실패 시 PR에 코멘트
+      - name: Add Unit Test Results to PR
         uses: mikepenz/action-junit-report@v3.8.0
         if: always()
         with:
           report_paths: animory/build/test-results/test/TEST-*.xml
     
+      - name: Add Jacoco Test coverage to PR
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: |
+            ${{ github.workspace }}/animory/build/reports/jacoco/test/jacocoTestReport.xml
+          min-coverage-overall: 50
+          min-coverage-changed-files: 50

--- a/animory/build.gradle
+++ b/animory/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.15'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	id 'jacoco' // Java Code Coverage
 }
 
 group = 'com.daggle'
@@ -55,6 +56,23 @@ dependencies {
 	testImplementation 'io.github.autoparams:autoparams:3.1.0' // test case random generator
 }
 
+// Test Task 설정
 tasks.named('test') {
 	useJUnitPlatform()
+
+	finalizedBy('jacocoTestReport') // Code Coverage 검사
+}
+
+// Jacoco (Java Code Coverage) 설정
+jacoco {
+	toolVersion = "0.8.10"
+}
+
+jacocoTestReport {
+	reports {
+		xml.required = true
+		csv.required = false
+		html.required = true
+		html.destination file("${buildDir}/reports/jacocoReport")
+	}
 }


### PR DESCRIPTION
## 작업 내용
- Jacoco 라고 부르는 plugin 을 추가하고, gradle test task 에 추가하였습니다.
- GitHub Actions Workflow에서 build 이후 결과를 PR에 코멘트로 추가하는 작업을 등록하였습니다.
- coverage는 50%로 설정되어있고, 충족하지 못한다고 해서 빌드가 실패하지 않게 하였습니다.



Close #69 