### PR TITLE
File server 분리 초안

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/fileserver/FileController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/fileserver/FileController.java
@@ -1,0 +1,21 @@
+package com.daggle.animory.domain.fileserver;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class FileController {
+
+    // 또는 로직이 복잡하다면 중간에 Service 추가
+    private final FileRepository localFileRepository;
+
+    @GetMapping("/file/{fileUrl}")
+    public ResponseEntity<Resource> getFile(@PathVariable final String fileUrl) {
+        return ResponseEntity.ok().body(localFileRepository.getFile(fileUrl));
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/domain/fileserver/FileRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/fileserver/FileRepository.java
@@ -1,0 +1,11 @@
+package com.daggle.animory.domain.fileserver;
+
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileRepository {
+
+    Resource getFile(String fileUrl);
+
+    String storeFile(MultipartFile file);
+}

--- a/animory/src/main/java/com/daggle/animory/domain/fileserver/LocalFileRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/fileserver/LocalFileRepository.java
@@ -1,9 +1,11 @@
-package com.daggle.animory.domain.pet.service.fileIO;
+package com.daggle.animory.domain.fileserver;
 
 
 import com.daggle.animory.common.error.exception.BadRequest400;
 import com.daggle.animory.common.error.exception.InternalServerError500;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,35 +17,44 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.util.Objects;
 
 @Service
-public class PetFileStorageService implements FileStorageService{
+public class LocalFileRepository implements FileRepository {
     private final Path fileStorageLocation;
 
-    public PetFileStorageService(@Value("${upload-path}") String path){
+    @Value("${file-server-domain}")
+    private String fileUrlPrefix;
+
+    public LocalFileRepository(@Value("${upload-path}") final String path){
         this.fileStorageLocation = Paths.get(path).toAbsolutePath().normalize();
         try{
             Files.createDirectories(this.fileStorageLocation);
         }
-        catch(Exception ex){
+        catch(final Exception ex){
             throw new InternalServerError500("디렉토리를 만들 수 없습니다.");
         }
     }
 
-    public String storeFile(MultipartFile file){
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMddhhmmss_");
-        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-        String time = simpleDateFormat.format(timestamp);
+    public Resource getFile(final String fileUrl){
+        throw new NotImplementedException("NotImplemented yet"); // TODO: implement
+    }
 
-        String fileName = time + StringUtils.cleanPath(file.getOriginalFilename());
+    public String storeFile(final MultipartFile file){
+        final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMddhhmmss_");
+        final Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        final String time = simpleDateFormat.format(timestamp);
+
+        final String fileName = time + StringUtils.cleanPath(Objects.requireNonNull(file.getOriginalFilename()));
+
         try{
             if(fileName.contains("..")){
                 throw new BadRequest400("파일이 유효하지 않은 경로를 포함하고 있습니다." + fileName);
             }
-            Path targetLocation = this.fileStorageLocation.resolve(fileName);
+            final Path targetLocation = this.fileStorageLocation.resolve(fileName);
             Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
             return fileName;
-        }catch(IOException ex){
+        }catch(final IOException ex){
             throw new BadRequest400("파일 " + fileName +"을 저장할 수 없습니다. 다시 시도하여주십시오.");
         }
     }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/fileIO/FileStorageService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/fileIO/FileStorageService.java
@@ -1,7 +1,0 @@
-package com.daggle.animory.domain.pet.service.fileIO;
-
-import org.springframework.web.multipart.MultipartFile;
-
-public interface FileStorageService {
-    String storeFile(MultipartFile file);
-}

--- a/animory/src/main/resources/application.yml
+++ b/animory/src/main/resources/application.yml
@@ -31,18 +31,22 @@ spring:
       max-file-size: "300MB"
       max-request-size: "300MB"
 
+# File Server Path
 upload-path: "./files_upload_location/"
+file-server-domain: "http://localhost:8080/"
 
+# Logging
 logging.level:
     '[com.daggle.animory]': DEBUG
     '[org.hibernate.type]': TRACE
 
+# API Docs
 springdoc.swagger-ui:
     enabled: true
     path: /docs
     tags-sorter: alpha # 태그를 알파벳 순으로 정렬합니다.
 
-  # security
+# Security
 jwt:
   header: Authorization
   secret: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK


### PR DESCRIPTION
## 작업 내용
- File Server 를 분리하려는 시도 입니다.

- 기존의 FileRepository 의 유일한 구현체는 Pet 이라는 이름과 관련이 없어서 LocalFileRepository 로 이름 변경하였습니다.
- File Server Domain Prefix 는 각 서버 별로 환경변수로 등록된 property 를 불러와서 사용하면 될 것 같습니다.(download url 제공할 때)
- File 저장이 필요한 각 다른 도메인에서 FileRepository를 가져가서 사용하면 될 듯 합니다. 추가적으로 Method name이 JPA method 와 완전 동일하다면(save, findByName 등) .. ?



Close #81 