### PR TITLE
feat/#46 동영상 및 이미지 업로드 기능 구현 -> 하나의 메소드로 통합

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/fileserver/FileController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/fileserver/FileController.java
@@ -1,11 +1,21 @@
 package com.daggle.animory.domain.fileserver;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,7 +25,19 @@ public class FileController {
     private final FileRepository localFileRepository;
 
     @GetMapping("/file/{fileUrl}")
-    public ResponseEntity<Resource> getFile(@PathVariable final String fileUrl) {
-        return ResponseEntity.ok().body(localFileRepository.getFile(fileUrl));
+    public ResponseEntity<Resource> getFile(@PathVariable final String fileUrl) throws IOException {
+        Path path = Paths.get(fileUrl);
+        String contentType = Files.probeContentType(path);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentDisposition(
+                ContentDisposition.builder("attachment")
+                        .filename(fileUrl, StandardCharsets.UTF_8)
+                        .build());
+        headers.add(HttpHeaders.CONTENT_TYPE, contentType);
+        Resource resource = localFileRepository.getFile(fileUrl);
+
+        return new ResponseEntity<>(resource, headers, HttpStatus.OK);
+
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/fileserver/LocalFileRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/fileserver/LocalFileRepository.java
@@ -5,11 +5,15 @@ import com.daggle.animory.common.error.exception.BadRequest400;
 import com.daggle.animory.common.error.exception.InternalServerError500;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +41,11 @@ public class LocalFileRepository implements FileRepository {
     }
 
     public Resource getFile(final String fileUrl){
-        throw new NotImplementedException("NotImplemented yet"); // TODO: implement
+        try{
+            return new InputStreamResource(new FileInputStream(fileUrl));
+        }catch(FileNotFoundException ex){
+            throw new BadRequest400("해당 파일을 찾을 수 없습니다.");
+        }
     }
 
     public String storeFile(final MultipartFile file){

--- a/animory/src/test/java/com/daggle/animory/domain/fileserver/FileControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/fileserver/FileControllerTest.java
@@ -1,0 +1,29 @@
+package com.daggle.animory.domain.fileserver;
+
+import com.daggle.animory.testutil.webmvctest.BaseWebMvcTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(FileController.class)
+class FileControllerTest extends BaseWebMvcTest {
+    @MockBean
+    LocalFileRepository localFileRepository;
+
+    @Nested
+    class 파일불러오기{
+        @Test
+        void 성공_파일_불러오기() throws Exception{
+            ResultActions resultActions = mvc.perform(
+                    get("/file/somefile.mp4"))
+                    .andExpect(status().isOk());
+            String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+            System.out.println("테스트: " + responseBody);
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 세인님께서 제안하신 의견대로 파일 요청 부분을 분리한 후 하나의 메소드로 통합하였습니다.
- 파일의 형식은 들어온 path 에 따라서 인식이 가능하니 image든 video든 전부 전달이 가능합니다.

## 논의하고 싶은 내용
- 한 가지 걸리는 점이 있습니다. 물론 나중에 수정이 들어갈 것 같지만 지금 파일 경로를 직접 입력받아 요청이 들어가는데, spring security에서 일부 문자를 자르는 것 같더라구요 ../으로 상위 디렉토리에 접근한다던지 이런 걸 막기 위함인것 같은데 나중에는 순수한 파일 이름이나 외부 url로 접근하도록 수정하는 게 좋아보입니다. 
예외 클래스 이름 --> org.springframework.security.web.firewall.requestrejectedexception




Close #46 