### PR TITLE
Pet API 내부구현 1차 PR

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/fileserver/LocalFileRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/fileserver/LocalFileRepository.java
@@ -6,6 +6,7 @@ import com.daggle.animory.common.error.exception.InternalServerError500;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,7 +20,7 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Objects;
 
-@Service
+@Repository
 public class LocalFileRepository implements FileRepository {
     private final Path fileStorageLocation;
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/PetController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/PetController.java
@@ -13,8 +13,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Optional;
-
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -31,23 +29,25 @@ public class PetController {
             @RequestPart(value = "profileVideo") final MultipartFile video
     ) {
 
-        return Response.success(petService.registerPet(account.getAccount(), petRegisterRequestDto, image, video));
+        return Response.success(
+                petService.registerPet(account.getAccount(), petRegisterRequestDto, image, video));
     }
 
-    @PatchMapping(value = "", consumes = {"multipart/form-data"})
-    public Response<UpdatePetSuccessDto> registerPet(
-            @RequestPart(value = "petInfo") final Optional<PetUpdateRequestDto> petUpdateRequestDto,
-            @RequestPart(value = "profileImage") final Optional<MultipartFile> image,
-            @RequestPart(value = "profileVideo") final Optional<MultipartFile> video
+    @PatchMapping(value = "/{petId}", consumes = {"multipart/form-data"})
+    public Response<UpdatePetSuccessDto> updatePet(
+            @PathVariable final int petId,
+            @RequestPart(value = "petInfo") final PetUpdateRequestDto petUpdateRequestDto,
+            @RequestPart(value = "profileImage", required = false) final MultipartFile image,
+            @RequestPart(value = "profileVideo", required = false) final MultipartFile video
     ) {
 
-        return Response.success(petService.updatePet(petUpdateRequestDto, image, video));
+        return Response.success(
+                petService.updatePet(petId, petUpdateRequestDto, image, video));
     }
 
 
     /**
-     * Pagination이 아닌, 각 8개씩 반환합니다.
-     * 이후 더보기 버튼을 통해 다른 API를 호출되는 시나리오 입니다.
+     * Pagination이 아닌, 각 8개씩 반환합니다. 이후 더보기 버튼을 통해 다른 API를 호출되는 시나리오 입니다.
      */
     @GetMapping("/profiles")
     public Response<PetProfilesDto> getPetProfiles() {

--- a/animory/src/main/java/com/daggle/animory/domain/pet/PetController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/PetController.java
@@ -45,6 +45,12 @@ public class PetController {
                 petService.updatePet(petId, petUpdateRequestDto, image, video));
     }
 
+    @GetMapping(value = "/register-info/{petId}")
+    public Response<PetRegisterInfoDto> getPetRegisterInfo(@PathVariable final int petId) {
+
+        return Response.success(
+                petService.getRegisterInfo(petId));
+    }
 
     /**
      * Pagination이 아닌, 각 8개씩 반환합니다. 이후 더보기 버튼을 통해 다른 API를 호출되는 시나리오 입니다.

--- a/animory/src/main/java/com/daggle/animory/domain/pet/PetController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/PetController.java
@@ -1,6 +1,7 @@
 package com.daggle.animory.domain.pet;
 
 import com.daggle.animory.common.Response;
+import com.daggle.animory.common.security.UserDetailsImpl;
 import com.daggle.animory.domain.pet.dto.request.PetRegisterRequestDto;
 import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
 import com.daggle.animory.domain.pet.dto.response.*;
@@ -8,6 +9,7 @@ import com.daggle.animory.domain.pet.service.PetService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -23,19 +25,20 @@ public class PetController {
 
     @PostMapping(value = "", consumes = {"multipart/form-data"})
     public Response<RegisterPetSuccessDto> registerPet(
-        @RequestPart(value = "petInfo") final PetRegisterRequestDto petRegisterRequestDto,
-        @RequestPart(value = "profileImage") final MultipartFile image,
-        @RequestPart(value = "profileVideo") final MultipartFile video
+            @AuthenticationPrincipal final UserDetailsImpl account,
+            @RequestPart(value = "petInfo") final PetRegisterRequestDto petRegisterRequestDto,
+            @RequestPart(value = "profileImage") final MultipartFile image,
+            @RequestPart(value = "profileVideo") final MultipartFile video
     ) {
 
-        return Response.success(petService.registerPet(petRegisterRequestDto, image, video));
+        return Response.success(petService.registerPet(account.getAccount(), petRegisterRequestDto, image, video));
     }
 
     @PatchMapping(value = "", consumes = {"multipart/form-data"})
     public Response<UpdatePetSuccessDto> registerPet(
-        @RequestPart(value = "petInfo") final Optional<PetUpdateRequestDto> petUpdateRequestDto,
-        @RequestPart(value = "profileImage") final Optional<MultipartFile> image,
-        @RequestPart(value = "profileVideo") final Optional<MultipartFile> video
+            @RequestPart(value = "petInfo") final Optional<PetUpdateRequestDto> petUpdateRequestDto,
+            @RequestPart(value = "profileImage") final Optional<MultipartFile> image,
+            @RequestPart(value = "profileVideo") final Optional<MultipartFile> video
     ) {
 
         return Response.success(petService.updatePet(petUpdateRequestDto, image, video));

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/PetPolygonProfileDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/PetPolygonProfileDto.java
@@ -2,7 +2,9 @@ package com.daggle.animory.domain.pet.dto;
 
 import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetPolygonProfile;
+import lombok.Builder;
 
+@Builder
 public record PetPolygonProfileDto(
         int intelligence,
         int affinity,
@@ -10,6 +12,7 @@ public record PetPolygonProfileDto(
         int adaptability,
         int activeness
 ) {
+
     public PetPolygonProfile toEntity(Pet pet) {
         return PetPolygonProfile.builder()
                 .pet(pet)
@@ -18,6 +21,16 @@ public record PetPolygonProfileDto(
                 .athletic(athletic)
                 .adaptability(adaptability)
                 .activeness(activeness)
+                .build();
+    }
+
+    public static PetPolygonProfileDto fromEntity(PetPolygonProfile petPolygonProfile) {
+        return PetPolygonProfileDto.builder()
+                .intelligence(petPolygonProfile.getIntelligence())
+                .affinity(petPolygonProfile.getAffinity())
+                .athletic(petPolygonProfile.getAthletic())
+                .adaptability(petPolygonProfile.getAdaptability())
+                .activeness(petPolygonProfile.getActiveness())
                 .build();
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/PetPolygonProfileDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/PetPolygonProfileDto.java
@@ -1,10 +1,23 @@
 package com.daggle.animory.domain.pet.dto;
 
+import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.pet.entity.PetPolygonProfile;
+
 public record PetPolygonProfileDto(
-    int intelligence,
-    int affinity,
-    int athletic,
-    int adaptability,
-    int activeness
+        int intelligence,
+        int affinity,
+        int athletic,
+        int adaptability,
+        int activeness
 ) {
+    public PetPolygonProfile toEntity(Pet pet) {
+        return PetPolygonProfile.builder()
+                .pet(pet)
+                .intelligence(intelligence)
+                .affinity(affinity)
+                .athletic(athletic)
+                .adaptability(adaptability)
+                .activeness(activeness)
+                .build();
+    }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
@@ -5,18 +5,19 @@ import com.daggle.animory.domain.pet.entity.AdoptionStatus;
 import com.daggle.animory.domain.pet.entity.NeutralizationStatus;
 import com.daggle.animory.domain.pet.entity.PetType;
 import com.daggle.animory.domain.pet.entity.Sex;
+import javax.validation.constraints.NotNull;
 
 public record PetRegisterRequestDto(
-    String name,
-    String age,
-    PetType type,
-    float weight,
-    String size,
-    Sex sex,
-    String vaccinationStatus,
-    AdoptionStatus adoptionStatus,
-    NeutralizationStatus neutralizationStatus,
-    String description,
-    PetPolygonProfileDto petPolygonProfileDto
+        @NotNull(message = "이름을 입력해주세요.") String name,
+        @NotNull(message = "나이를 입력해주세요.") String age,
+        @NotNull(message = "종을 입력해주세요.") PetType type,
+        float weight,
+        String size,
+        @NotNull(message = "성별을 입력해주세요.") Sex sex,
+        String vaccinationStatus,
+        @NotNull(message = "입양 상태를 입력해주세요.") AdoptionStatus adoptionStatus,
+        NeutralizationStatus neutralizationStatus,
+        String description,
+        PetPolygonProfileDto petPolygonProfileDto
 ) {
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
@@ -1,10 +1,14 @@
 package com.daggle.animory.domain.pet.dto.request;
 
 import com.daggle.animory.domain.pet.dto.PetPolygonProfileDto;
-import com.daggle.animory.domain.pet.entity.*;
+import com.daggle.animory.domain.pet.entity.AdoptionStatus;
+import com.daggle.animory.domain.pet.entity.NeutralizationStatus;
+import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.pet.entity.Sex;
 import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
 import com.daggle.animory.domain.shelter.entity.Shelter;
-
+import java.time.LocalDate;
 import javax.validation.constraints.NotNull;
 
 public record PetRegisterRequestDto(
@@ -17,6 +21,7 @@ public record PetRegisterRequestDto(
         String vaccinationStatus,
         @NotNull(message = "입양 상태를 입력해주세요.") AdoptionStatus adoptionStatus,
         NeutralizationStatus neutralizationStatus,
+        LocalDate protectionExpirationDate,
         String description,
         PetPolygonProfileDto petPolygonProfileDto
 ) {
@@ -29,7 +34,7 @@ public record PetRegisterRequestDto(
                 .weight(weight)
                 .sex(sex)
                 .description(description)
-                .protectionExpirationDate(null)
+                .protectionExpirationDate(protectionExpirationDate)
                 .vaccinationStatus(vaccinationStatus)
                 .neutralizationStatus(neutralizationStatus)
                 .adoptionStatus(adoptionStatus)

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
@@ -1,10 +1,10 @@
 package com.daggle.animory.domain.pet.dto.request;
 
 import com.daggle.animory.domain.pet.dto.PetPolygonProfileDto;
-import com.daggle.animory.domain.pet.entity.AdoptionStatus;
-import com.daggle.animory.domain.pet.entity.NeutralizationStatus;
-import com.daggle.animory.domain.pet.entity.PetType;
-import com.daggle.animory.domain.pet.entity.Sex;
+import com.daggle.animory.domain.pet.entity.*;
+import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
+import com.daggle.animory.domain.shelter.entity.Shelter;
+
 import javax.validation.constraints.NotNull;
 
 public record PetRegisterRequestDto(
@@ -20,4 +20,21 @@ public record PetRegisterRequestDto(
         String description,
         PetPolygonProfileDto petPolygonProfileDto
 ) {
+    public Pet toEntity(Shelter shelter, String imageUrl, String videoUrl) {
+        return Pet.builder()
+                .name(name)
+                .birthDate(PetAgeToBirthDateConverter.ageToBirthDate(age))
+                .type(type)
+                .weight(weight)
+                .description(description)
+                .protectionExpirationDate(null)
+                .vaccinationStatus(vaccinationStatus)
+                .neutralizationStatus(neutralizationStatus)
+                .adoptionStatus(adoptionStatus)
+                .profileImageUrl(imageUrl)
+                .profileShortFormUrl(videoUrl)
+                .size(size)
+                .shelter(shelter)
+                .build();
+    }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
@@ -20,12 +20,14 @@ public record PetRegisterRequestDto(
         String description,
         PetPolygonProfileDto petPolygonProfileDto
 ) {
+
     public Pet toEntity(Shelter shelter, String imageUrl, String videoUrl) {
         return Pet.builder()
                 .name(name)
                 .birthDate(PetAgeToBirthDateConverter.ageToBirthDate(age))
                 .type(type)
                 .weight(weight)
+                .sex(sex)
                 .description(description)
                 .protectionExpirationDate(null)
                 .vaccinationStatus(vaccinationStatus)

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetUpdateRequestDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetUpdateRequestDto.java
@@ -5,20 +5,20 @@ import com.daggle.animory.domain.pet.entity.AdoptionStatus;
 import com.daggle.animory.domain.pet.entity.NeutralizationStatus;
 import com.daggle.animory.domain.pet.entity.PetType;
 import com.daggle.animory.domain.pet.entity.Sex;
-
-import java.util.Optional;
+import javax.validation.constraints.NotNull;
 
 public record PetUpdateRequestDto(
-    Optional<String> name,
-    Optional<String> age,
-    Optional<PetType> type,
-    Optional<Float> weight,
-    Optional<String> size,
-    Optional<Sex> sex,
-    Optional<String> vaccinationStatus,
-    Optional<AdoptionStatus> adoptionStatus,
-    Optional<NeutralizationStatus> neutralizationStatus,
-    Optional<String> description,
-    Optional<PetPolygonProfileDto> petPolygonProfileDto
+        @NotNull(message = "이름을 입력해주세요.") String name,
+        @NotNull(message = "나이를 입력해주세요.") String age,
+        @NotNull(message = "종을 입력해주세요.") PetType type,
+        float weight,
+        String size,
+        @NotNull(message = "성별을 입력해주세요.") Sex sex,
+        String vaccinationStatus,
+        @NotNull(message = "입양 상태를 입력해주세요.") AdoptionStatus adoptionStatus,
+        NeutralizationStatus neutralizationStatus,
+        String description,
+        PetPolygonProfileDto petPolygonProfileDto
 ) {
+
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetUpdateRequestDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetUpdateRequestDto.java
@@ -5,6 +5,7 @@ import com.daggle.animory.domain.pet.entity.AdoptionStatus;
 import com.daggle.animory.domain.pet.entity.NeutralizationStatus;
 import com.daggle.animory.domain.pet.entity.PetType;
 import com.daggle.animory.domain.pet.entity.Sex;
+import java.time.LocalDate;
 import javax.validation.constraints.NotNull;
 
 public record PetUpdateRequestDto(
@@ -18,6 +19,7 @@ public record PetUpdateRequestDto(
         @NotNull(message = "입양 상태를 입력해주세요.") AdoptionStatus adoptionStatus,
         NeutralizationStatus neutralizationStatus,
         String description,
+        LocalDate protectionExpirationDate,
         PetPolygonProfileDto petPolygonProfileDto
 ) {
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/response/PetRegisterInfoDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/response/PetRegisterInfoDto.java
@@ -1,0 +1,53 @@
+package com.daggle.animory.domain.pet.dto.response;
+
+import com.daggle.animory.domain.pet.dto.PetPolygonProfileDto;
+import com.daggle.animory.domain.pet.entity.AdoptionStatus;
+import com.daggle.animory.domain.pet.entity.NeutralizationStatus;
+import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.pet.entity.PetPolygonProfile;
+import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.pet.entity.Sex;
+import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record PetRegisterInfoDto(
+        String name,
+        String age,
+        PetType type,
+        float weight,
+        String size,
+        Sex sex,
+        String vaccinationStatus,
+        AdoptionStatus adoptionStatus,
+        NeutralizationStatus neutralizationStatus,
+        LocalDate protectionExpirationDate,
+        String description,
+        String profileImageUrl,
+        String profileShortFormUrl,
+        PetPolygonProfileDto petPolygonProfileDto
+) {
+
+    public static PetRegisterInfoDto fromEntity(Pet registerPet,
+            PetPolygonProfile petPolygonProfile) {
+        return PetRegisterInfoDto.builder()
+                .name(registerPet.getName())
+                .age(PetAgeToBirthDateConverter.birthDateToAge(registerPet.getBirthDate()))
+                .type(registerPet.getType())
+                .weight(registerPet.getWeight())
+                .size(registerPet.getSize())
+                .sex(registerPet.getSex())
+                .vaccinationStatus(registerPet.getVaccinationStatus())
+                .adoptionStatus(registerPet.getAdoptionStatus())
+                .neutralizationStatus(registerPet.getNeutralizationStatus())
+                .protectionExpirationDate(registerPet.getProtectionExpirationDate())
+                .description(registerPet.getDescription())
+                .profileImageUrl(registerPet.getProfileImageUrl())
+                .profileShortFormUrl(registerPet.getProfileShortFormUrl())
+                .petPolygonProfileDto(PetPolygonProfileDto.fromEntity(petPolygonProfile))
+                .build();
+    }
+
+}
+

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
@@ -1,5 +1,7 @@
 package com.daggle.animory.domain.pet.entity;
 
+import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
+import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
 import com.daggle.animory.domain.shelter.entity.Shelter;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
@@ -15,6 +17,7 @@ import java.time.LocalDate;
 @Table(name = "pet")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Pet {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
@@ -22,11 +25,17 @@ public class Pet {
     @NotNull
     private String name;
 
+    @NotNull
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDate birthDate;
 
+    @NotNull
     @Enumerated(EnumType.STRING)
     private PetType type;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Sex sex;
 
     private float weight;
 
@@ -41,11 +50,14 @@ public class Pet {
     @Enumerated(EnumType.STRING)
     private NeutralizationStatus neutralizationStatus;
 
+    @NotNull
     @Enumerated(EnumType.STRING)
     private AdoptionStatus adoptionStatus;
 
+    @NotNull
     private String profileImageUrl;
 
+    @NotNull
     private String profileShortFormUrl;
 
     private String size;
@@ -59,4 +71,23 @@ public class Pet {
     private PetPolygonProfile petPolygonProfile;
 
 
+    public void updateImage(String imageUrl) {
+        this.profileImageUrl = imageUrl;
+    }
+
+    public void updateVideo(String videoUrl) {
+        this.profileShortFormUrl = videoUrl;
+    }
+
+    public void updateInfo(PetUpdateRequestDto petUpdateRequestDto) {
+        this.name = petUpdateRequestDto.name();
+        this.birthDate = PetAgeToBirthDateConverter.ageToBirthDate(petUpdateRequestDto.age());
+        this.type = petUpdateRequestDto.type();
+        this.weight = petUpdateRequestDto.weight();
+        this.size = petUpdateRequestDto.size();
+        this.sex = petUpdateRequestDto.sex();
+        this.vaccinationStatus = petUpdateRequestDto.vaccinationStatus();
+        this.adoptionStatus = petUpdateRequestDto.adoptionStatus();
+        this.description = petUpdateRequestDto.description();
+    }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
@@ -87,7 +87,9 @@ public class Pet {
         this.size = petUpdateRequestDto.size();
         this.sex = petUpdateRequestDto.sex();
         this.vaccinationStatus = petUpdateRequestDto.vaccinationStatus();
+        this.neutralizationStatus = petUpdateRequestDto.neutralizationStatus();
         this.adoptionStatus = petUpdateRequestDto.adoptionStatus();
+        this.protectionExpirationDate = petUpdateRequestDto.protectionExpirationDate();
         this.description = petUpdateRequestDto.description();
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetPolygonProfile.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetPolygonProfile.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.domain.pet.entity;
 
+import com.daggle.animory.domain.pet.dto.PetPolygonProfileDto;
 import lombok.*;
 
 import javax.persistence.*;
@@ -11,6 +12,7 @@ import javax.persistence.*;
 @Table(name = "pet_polygon_profile")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PetPolygonProfile {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
@@ -31,4 +33,11 @@ public class PetPolygonProfile {
 
     private int activeness;
 
+    public void update(PetPolygonProfileDto petPolygonProfileDto) {
+        this.intelligence = petPolygonProfileDto.intelligence();
+        this.affinity = petPolygonProfileDto.affinity();
+        this.athletic = petPolygonProfileDto.athletic();
+        this.adaptability = petPolygonProfileDto.adaptability();
+        this.activeness = petPolygonProfileDto.activeness();
+    }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetPolygonRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetPolygonRepository.java
@@ -1,0 +1,8 @@
+package com.daggle.animory.domain.pet.repository;
+
+import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.pet.entity.PetPolygonProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetPolygonRepository extends JpaRepository<PetPolygonProfile, Integer> {
+}

--- a/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetPolygonRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetPolygonRepository.java
@@ -1,8 +1,10 @@
 package com.daggle.animory.domain.pet.repository;
 
-import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetPolygonProfile;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PetPolygonRepository extends JpaRepository<PetPolygonProfile, Integer> {
+
+    Optional<PetPolygonProfile> findByPetId(int petId);
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
@@ -1,4 +1,4 @@
-package com.daggle.animory.domain.pet;
+package com.daggle.animory.domain.pet.repository;
 
 import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetType;

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetService.java
@@ -1,29 +1,31 @@
 package com.daggle.animory.domain.pet.service;
 
 
+import com.daggle.animory.common.error.exception.NotFound404;
 import com.daggle.animory.common.error.exception.UnAuthorized401;
 import com.daggle.animory.domain.account.entity.Account;
 import com.daggle.animory.domain.fileserver.FileRepository;
-import com.daggle.animory.domain.pet.repository.PetPolygonRepository;
-import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.pet.dto.request.PetRegisterRequestDto;
 import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
 import com.daggle.animory.domain.pet.dto.response.*;
 import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.pet.entity.PetPolygonProfile;
+import com.daggle.animory.domain.pet.repository.PetPolygonRepository;
+import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shelter.ShelterRepository;
 import com.daggle.animory.domain.shelter.entity.Shelter;
+import java.net.URL;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Optional;
-
 
 @Service
 @RequiredArgsConstructor
 public class PetService {
+
     private final FileRepository fileRepository;
     private final ShelterRepository shelterRepository;
     private final PetRepository petRepository;
@@ -45,17 +47,21 @@ public class PetService {
         throw new NotImplementedException("NotImplemented yet");
     }
 
-    public RegisterPetSuccessDto registerPet(final Account account, final PetRegisterRequestDto petRequestDTO, final MultipartFile image, final MultipartFile video) {
+    public RegisterPetSuccessDto registerPet(final Account account,
+            final PetRegisterRequestDto petRequestDTO, final MultipartFile image,
+            final MultipartFile video) {
+
         // 이미지, 숏폼 파일 저장 후 url 얻어오기
-        String imageUrl = fileRepository.storeFile(image);
-        String videoUrl = fileRepository.storeFile(video);
+        URL imageUrl = fileRepository.save(image);
+        URL videoUrl = fileRepository.save(video);
 
         // 펫 등록을 요청한 유저의 보호소 조회
         Shelter shelter = shelterRepository.findByAccountId(account.getId())
                 .orElseThrow(() -> new UnAuthorized401("보호소 정보가 존재하지 않습니다."));
 
         // 펫 DB 저장
-        Pet registerPet = petRepository.save(petRequestDTO.toEntity(shelter, imageUrl, videoUrl));
+        Pet registerPet = petRepository.save(
+                petRequestDTO.toEntity(shelter, imageUrl.toString(), videoUrl.toString()));
 
         // 펫 다각형 프로필 DB 저장
         petPolygonRepository.save(petRequestDTO.petPolygonProfileDto().toEntity(registerPet));
@@ -63,7 +69,39 @@ public class PetService {
         return new RegisterPetSuccessDto(registerPet.getId());
     }
 
-    public UpdatePetSuccessDto updatePet(final Optional<PetUpdateRequestDto> petUpdateRequestDto, final Optional<MultipartFile> image, final Optional<MultipartFile> video) {
-        throw new NotImplementedException("NotImplemented yet");
+    public UpdatePetSuccessDto updatePet(final int petId,
+            final PetUpdateRequestDto petUpdateRequestDto, final MultipartFile image,
+            final MultipartFile video) {
+
+        // 펫 id로 Pet, PetPolygonProfile 얻어오기
+        Pet updatePet = petRepository.findById(petId)
+                .orElseThrow(() -> new NotFound404("등록되지 않은 펫입니다."));
+
+        PetPolygonProfile petPolygonProfile = petPolygonRepository.findByPetId(petId)
+                .orElseThrow(() -> new NotFound404("등록된 다각형 프로필이 존재하지 않습니다."));
+
+        // 이미지, 비디오 파일 업데이트
+        updateFile(updatePet, image, video);
+
+        // 펫 정보 업데이트
+        updatePet.updateInfo(petUpdateRequestDto);
+        petPolygonProfile.update(petUpdateRequestDto.petPolygonProfileDto());
+
+        return new UpdatePetSuccessDto(updatePet.getId());
+    }
+
+    // 이미지, 비디오 파일 수정 요청 시 기존 파일 삭제 후 업데이트
+    public void updateFile(final Pet updatePet, final MultipartFile image,
+            final MultipartFile video) {
+        if (image != null) {
+//            fileRepository.delete(updatePet.getProfileImageUrl());
+            URL imageUrl = fileRepository.save(image);
+            updatePet.updateImage(imageUrl.toString());
+        }
+        if (video != null) {
+//            fileRepository.delete(updatePet.getProfileShortFormUrl());
+            URL videoUrl = fileRepository.save(video);
+            updatePet.updateVideo(videoUrl.toString());
+        }
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetService.java
@@ -104,4 +104,18 @@ public class PetService {
             updatePet.updateVideo(videoUrl.toString());
         }
     }
+
+    // 기존의 펫 등록 정보 조회
+    public PetRegisterInfoDto getRegisterInfo(final int petId) {
+
+        // 펫 id로 Pet, PetPolygonProfile 얻어오기
+        Pet registerPet = petRepository.findById(petId)
+                .orElseThrow(() -> new NotFound404("등록되지 않은 펫입니다."));
+
+        PetPolygonProfile petPolygonProfile = petPolygonRepository.findByPetId(petId)
+                .orElseThrow(() -> new NotFound404("등록된 다각형 프로필이 존재하지 않습니다."));
+
+        // Pet -> PetRegisterInfoDto
+        return PetRegisterInfoDto.fromEntity(registerPet, petPolygonProfile);
+    }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetService.java
@@ -1,9 +1,18 @@
 package com.daggle.animory.domain.pet.service;
 
 
+import com.daggle.animory.common.error.exception.UnAuthorized401;
+import com.daggle.animory.domain.account.entity.Account;
+import com.daggle.animory.domain.fileserver.FileRepository;
+import com.daggle.animory.domain.pet.repository.PetPolygonRepository;
+import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.pet.dto.request.PetRegisterRequestDto;
 import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
 import com.daggle.animory.domain.pet.dto.response.*;
+import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.shelter.ShelterRepository;
+import com.daggle.animory.domain.shelter.entity.Shelter;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -13,7 +22,12 @@ import java.util.Optional;
 
 
 @Service
+@RequiredArgsConstructor
 public class PetService {
+    private final FileRepository fileRepository;
+    private final ShelterRepository shelterRepository;
+    private final PetRepository petRepository;
+    private final PetPolygonRepository petPolygonRepository;
 
     public PetProfilesDto getPetProfiles() {
         throw new NotImplementedException("NotImplemented yet");
@@ -31,8 +45,22 @@ public class PetService {
         throw new NotImplementedException("NotImplemented yet");
     }
 
-    public RegisterPetSuccessDto registerPet(final PetRegisterRequestDto petRequestDTO, final MultipartFile image, final MultipartFile video) {
-        throw new NotImplementedException("NotImplemented yet");
+    public RegisterPetSuccessDto registerPet(final Account account, final PetRegisterRequestDto petRequestDTO, final MultipartFile image, final MultipartFile video) {
+        // 이미지, 숏폼 파일 저장 후 url 얻어오기
+        String imageUrl = fileRepository.storeFile(image);
+        String videoUrl = fileRepository.storeFile(video);
+
+        // 펫 등록을 요청한 유저의 보호소 조회
+        Shelter shelter = shelterRepository.findByAccountId(account.getId())
+                .orElseThrow(() -> new UnAuthorized401("보호소 정보가 존재하지 않습니다."));
+
+        // 펫 DB 저장
+        Pet registerPet = petRepository.save(petRequestDTO.toEntity(shelter, imageUrl, videoUrl));
+
+        // 펫 다각형 프로필 DB 저장
+        petPolygonRepository.save(petRequestDTO.petPolygonProfileDto().toEntity(registerPet));
+
+        return new RegisterPetSuccessDto(registerPet.getId());
     }
 
     public UpdatePetSuccessDto updatePet(final Optional<PetUpdateRequestDto> petUpdateRequestDto, final Optional<MultipartFile> image, final Optional<MultipartFile> video) {

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
@@ -3,5 +3,8 @@ package com.daggle.animory.domain.shelter;
 import com.daggle.animory.domain.shelter.entity.Shelter;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ShelterRepository extends JpaRepository<Shelter, Integer> {
+    Optional<Shelter> findByAccountId(Integer accountId);
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
@@ -1,7 +1,7 @@
 package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.common.error.exception.NotFound404;
-import com.daggle.animory.domain.pet.PetRepository;
+import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
@@ -1,6 +1,6 @@
 package com.daggle.animory.domain.shortform;
 
-import com.daggle.animory.domain.pet.PetRepository;
+import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shortform.dto.request.ShortFormSearchCondition;
 import com.daggle.animory.domain.shortform.dto.response.CategoryShortFormPage;
 import com.daggle.animory.domain.shortform.dto.response.HomeShortFormPage;

--- a/animory/src/test/java/com/daggle/animory/domain/pet/PetRepositoryTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/pet/PetRepositoryTest.java
@@ -2,6 +2,7 @@ package com.daggle.animory.domain.pet;
 
 import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shelter.entity.Province;
 import com.daggle.animory.testutil.datajpatest.DataJpaTestWithDummyData;
 import org.junit.jupiter.api.Test;

--- a/animory/src/test/java/com/daggle/animory/testutil/datajpatest/DataJpaTestWithDummyData.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/datajpatest/DataJpaTestWithDummyData.java
@@ -2,7 +2,7 @@ package com.daggle.animory.testutil.datajpatest;
 
 
 import com.daggle.animory.domain.shelter.ShelterFixture;
-import com.daggle.animory.domain.pet.PetRepository;
+import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetType;
 import com.daggle.animory.domain.pet.fixture.PetFixture;


### PR DESCRIPTION
## 작업 내용
- Pet API는 크게 프로필 등록/수정 API와 프로필 조회 API로 나뉘어서 일단 프로필 등록/수정 부분 API 1차 PR 날립니다.
- 펫 프로필 등록, 수정, 등록 정보 조회 API 내부 구현 1차 완료 했습니다.
- API 문서와 피그마 디자인을 눈으로 볼 때 확인하지 못했던 누락된 부분들 반영하였습니다.

## 논의하고 싶은 내용
- 예외 처리가 필요한 부분, 리팩토링이 필요한 부분 말씀해주세요.
- 테스트 코드는 API 내부 구현이 완료된 후 다음주에 작성하려고 합니다. 테스트 코드를 작성하고 싶으신 분이 있다면 대신 해주시면 감사

## 공유하고 싶은 내용
- LocalDate 객체는 timezone 속성을 우리나라로 지정하지 않아도 서버 위치 기준으로 시간을 넣어준다고 합니다.

