### PR TITLE
Base Entity(createdAt, updatedAt) 추가

### DIFF
--- a/animory/build.gradle
+++ b/animory/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/animory/src/main/java/com/daggle/animory/common/config/JpaAuditConfiguration.java
+++ b/animory/src/main/java/com/daggle/animory/common/config/JpaAuditConfiguration.java
@@ -1,0 +1,2 @@
+package com.daggle.animory.common.config;public class JpaAuditConfiguration {
+}

--- a/animory/src/main/java/com/daggle/animory/common/config/JpaAuditConfiguration.java
+++ b/animory/src/main/java/com/daggle/animory/common/config/JpaAuditConfiguration.java
@@ -1,2 +1,9 @@
-package com.daggle.animory.common.config;public class JpaAuditConfiguration {
+package com.daggle.animory.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfiguration {
 }

--- a/animory/src/main/java/com/daggle/animory/common/entity/BaseEntity.java
+++ b/animory/src/main/java/com/daggle/animory/common/entity/BaseEntity.java
@@ -1,0 +1,2 @@
+package com.daggle.animory.common.entity;public class BaseEntity {
+}

--- a/animory/src/main/java/com/daggle/animory/common/entity/BaseEntity.java
+++ b/animory/src/main/java/com/daggle/animory/common/entity/BaseEntity.java
@@ -1,2 +1,26 @@
-package com.daggle.animory.common.entity;public class BaseEntity {
+package com.daggle.animory.common.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd-HH-mm-ss")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd-HH-mm-ss")
+    private LocalDateTime updatedAt;
 }

--- a/animory/src/main/java/com/daggle/animory/domain/account/entity/Account.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/entity/Account.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.domain.account.entity;
 
+import com.daggle.animory.common.entity.BaseEntity;
 import lombok.*;
 
 import javax.persistence.*;
@@ -11,7 +12,7 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 @Table(name = "account")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Account {
+public class Account extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/dto/request/PetRegisterRequestDto.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Builder
 public record PetRegisterRequestDto(
@@ -41,7 +40,6 @@ public record PetRegisterRequestDto(
                 .profileImageUrl(imageUrl)
                 .profileShortFormUrl(videoUrl)
                 .size(size)
-                .createdAt(LocalDateTime.now())
                 .shelter(shelter)
                 .build();
     }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.domain.pet.entity;
 
+import com.daggle.animory.common.entity.BaseEntity;
 import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
 import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
 import com.daggle.animory.domain.shelter.entity.Shelter;
@@ -9,7 +10,6 @@ import lombok.*;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Table(name = "pet")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Pet {
+public class Pet extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,7 +43,7 @@ public class Pet {
     @Column(length = 1000)
     private String description;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate protectionExpirationDate;
 
     private String vaccinationStatus;
@@ -62,9 +62,6 @@ public class Pet {
     private String profileShortFormUrl;
 
     private String size;
-
-    @Column(nullable = false, columnDefinition = "datetime")
-    private LocalDateTime createdAt;
 
     @ManyToOne
     @JoinColumn(name = "shelter_id")

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetPolygonProfile.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetPolygonProfile.java
@@ -33,7 +33,7 @@ public class PetPolygonProfile {
 
     private int activeness;
 
-    public void update(PetPolygonProfileDto petPolygonProfileDto) {
+    public void update(final PetPolygonProfileDto petPolygonProfileDto) {
         this.intelligence = petPolygonProfileDto.intelligence();
         this.affinity = petPolygonProfileDto.affinity();
         this.athletic = petPolygonProfileDto.athletic();

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
@@ -29,6 +29,7 @@ public class PetWriteService {
     private final ShelterRepository shelterRepository;
     private final PetRepository petRepository;
     private final PetPolygonRepository petPolygonRepository;
+
     private final PetValidator petValidator;
 
     public RegisterPetSuccessDto registerPet(final Account account,

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Shelter.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Shelter.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.domain.shelter.entity;
 
+import com.daggle.animory.common.entity.BaseEntity;
 import com.daggle.animory.domain.account.entity.Account;
 import lombok.*;
 
@@ -12,7 +13,7 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 @Table(name = "shelter")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Shelter {
+public class Shelter extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;

--- a/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
@@ -6,10 +6,8 @@ import com.daggle.animory.domain.account.dto.request.ShelterAddressSignUpDto;
 import com.daggle.animory.domain.account.dto.request.ShelterSignUpDto;
 import com.daggle.animory.domain.shelter.entity.Province;
 import com.daggle.animory.testutil.webmvctest.BaseWebMvcTest;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -20,9 +18,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @Import(AccountController.class)
 public class AccountControllerTest extends BaseWebMvcTest {
-
-    @Autowired
-    ObjectMapper om;
 
     @MockBean
     AccountService accountService;

--- a/animory/src/test/java/com/daggle/animory/domain/pet/PetRepositoryTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/pet/PetRepositoryTest.java
@@ -35,7 +35,7 @@ class PetRepositoryTest extends DataJpaTestWithDummyData {
         final Integer shelterId = 1;
         final Page<Pet> page = petRepository.findByShelterId(shelterId, PageRequest.of(0, 10));
 
-        List<Pet> pets = page.getContent();
+        final List<Pet> pets = page.getContent();
         print(pets);
 
         pets.forEach(

--- a/animory/src/test/java/com/daggle/animory/domain/pet/fixture/PetFixture.java
+++ b/animory/src/test/java/com/daggle/animory/domain/pet/fixture/PetFixture.java
@@ -4,7 +4,6 @@ import com.daggle.animory.domain.pet.entity.*;
 import com.daggle.animory.domain.shelter.entity.Shelter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +24,6 @@ public class PetFixture {
             .profileImageUrl("http://amazon.server/api/petImage/20231001104521_test1.jpg")
             .profileShortFormUrl("http://amazon.server/api/petVideo/20231001104521_test1.mp4")
             .size("작아요 소형견입니다.")
-            .createdAt(LocalDateTime.now())
             .shelter(shelter)
             .build();
     }
@@ -50,7 +48,6 @@ public class PetFixture {
                     .profileImageUrl("http://amazon.server/api/petImage/20231001104521_test" + i + ".jpg")
                     .profileShortFormUrl("http://amazon.server/api/petVideo/20231001104521_test" + i + ".mp4")
                     .size("작아요 소형견입니다." + i)
-                    .createdAt(LocalDateTime.now())
                     .shelter(shelter)
                     .build()
             );

--- a/animory/src/test/java/com/daggle/animory/testutil/datajpatest/DataJpaTestWithDummyData.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/datajpatest/DataJpaTestWithDummyData.java
@@ -12,10 +12,12 @@ import com.daggle.animory.domain.shelter.entity.Shelter;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.List;
 
 @DataJpaTest
+@EnableJpaAuditing
 public abstract class DataJpaTestWithDummyData extends WithTimeSupportObjectMapper {
 
     @Autowired

--- a/animory/src/test/java/com/daggle/animory/testutil/datajpatest/WithTimeSupportObjectMapper.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/datajpatest/WithTimeSupportObjectMapper.java
@@ -3,11 +3,13 @@ package com.daggle.animory.testutil.datajpatest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * time type serialization 설정이 추가된 object mapper 가 지원됩니다.
  * DataJpaTest 등에서 결과를 콘솔에 찍어보고자 할때 상속해서 사용하면 좋을 듯 합니다.
  */
+@Slf4j
 public abstract class WithTimeSupportObjectMapper {
 
     protected ObjectMapper om = new ObjectMapper()
@@ -15,9 +17,9 @@ public abstract class WithTimeSupportObjectMapper {
 
     protected void print(final Object o) {
         try{
-            System.out.println(om.writerWithDefaultPrettyPrinter().writeValueAsString(o));
+            log.debug(om.writerWithDefaultPrettyPrinter().writeValueAsString(o));
         } catch (final JsonProcessingException e){
-            System.out.println("json parsing error: " + e.getMessage());
+            log.debug("json parsing error: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
## 작업 내용
- Base Entity를 추가하였습니다. createdAt과 updatedAt이라는 필드를 가지고 있는데, insert, update 가 실행될 때 자동으로 값이 추가되고 변경되도록 annotation 처리 하였습니다.
- 현재 사용중인 Pet, Shelter, Account Entity에서 상속하도록 처리하였습니다.


- test code에서 Slf4j 사용하기 위해서, lombok 의존성을 test 범위로 확장하였습니다.




Close #120 