### PR TITLE
펫 입양완료 API 추가 

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
@@ -90,5 +90,14 @@ public class PetController implements PetControllerApi {
         return Response.success(petReadService.getPetDetail(petId));
     }
 
+    // Pet 입양 완료 상태 등록
+    @PostMapping("/adoption/{petId}")
+    @Authorized(AccountRole.SHELTER)
+    public Response<Void> updatePetAdopted(final Account account,
+                                           @PathVariable final int petId) {
+        petWriteService.updatePetAdopted(account, petId);
+        return Response.success();
+    }
+
 
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/AdoptionStatus.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/AdoptionStatus.java
@@ -2,5 +2,6 @@ package com.daggle.animory.domain.pet.entity;
 
 public enum AdoptionStatus {
     YES,
-    NO
+    NO,
+    UNABLE
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
@@ -80,6 +80,11 @@ public class Pet extends BaseEntity {
         this.profileShortFormUrl = videoUrl;
     }
 
+    public void setAdopted() {
+        this.adoptionStatus = AdoptionStatus.YES;
+        this.protectionExpirationDate = null;
+    }
+
     public void updateInfo(final PetUpdateRequestDto petUpdateRequestDto) {
         this.name = petUpdateRequestDto.name();
         this.birthDate = PetAgeToBirthDateConverter.ageToBirthDate(petUpdateRequestDto.age());

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
@@ -82,6 +82,17 @@ public class PetWriteService {
         return new UpdatePetSuccessDto(updatePet.getId());
     }
 
+    public void updatePetAdopted(final Account account,
+                                 final int petId) {
+        final Pet pet = petRepository.findById(petId)
+            .orElseThrow(() -> new NotFound404("등록되지 않은 펫입니다."));
+
+        petValidator.validatePetUpdateAuthority(account, pet);
+
+        // 입양상태를 YES로 변경하고, 보호 만료일을 null로 바꾼다.
+        pet.setAdopted(); // TODO: 더 이상 보호소와 관련이 없어서.. 연결된 보호소 정보를 제거할 필요 ?
+    }
+
     // 이미지, 비디오 파일 수정 요청 시 기존 파일 삭제 후 업데이트
     private void updateFile(final Pet updatePet, final MultipartFile image,
                            final MultipartFile video) {
@@ -94,7 +105,6 @@ public class PetWriteService {
             updatePet.updateVideo(videoUrl.toString());
         }
     }
-
 
 
 }


### PR DESCRIPTION
## 작업 내용
- AdoptionStatus 에 YES, NO 그리고 UNABLE 상태를 추가하였습니다.(보호만료일이 지났으나 미입양 상태인 동물 데이터를 위함)
- 보호소 계정에 소속된 Pet의 입양 상태를 완료로 변경하고, 보호만료일을 null로 변경하는 API를 추가했습니다.


## 논의하고 싶은 내용
- 입양이 완료되면, 기존 보호소와 연관관계가 사라져야 하지 않은지.. ?



Close #127 