### PR TITLE
근처 동물 보호소 조회 API

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterController.java
@@ -1,12 +1,15 @@
 package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.common.Response;
+import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.Min;
+import java.util.List;
+
 @Validated
 @RestController
 @RequiredArgsConstructor
@@ -18,5 +21,13 @@ public class ShelterController {
     public Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) final Integer shelterId,
                                                    @RequestParam("page") @Min(0) final int page) {
         return Response.success(shelterService.getShelterProfile(shelterId, page));
+    }
+
+    /** 등록된 보호소 필터링 API <br>
+     * 리스트 형태의 보호소 정보를 입력받아서, DB에서 kakaoLocationId가 일치하는 Shelter목록을 반환한다.
+     */
+    @PostMapping("/filter")
+    public Response<List<ShelterLocationDto>> filterExistShelterListByLocationId(@RequestBody final List<Integer> shelterLocationIdList) {
+        return Response.success(shelterService.filterExistShelterListByLocationId(shelterLocationIdList));
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
@@ -12,7 +12,7 @@ public interface ShelterRepository extends JpaRepository<Shelter, Integer> {
 
     @Query("select s.id " +
         "from Shelter s " +
-        "where s.kakaoLocationId " +
+        "where s.address.kakaoLocationId " +
         "in :shelterLocationIdList")
     List<Shelter> findAllByKakaoLocationIdIn(List<Integer> shelterLocationIdList);
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
@@ -2,9 +2,17 @@ package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.domain.shelter.entity.Shelter;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ShelterRepository extends JpaRepository<Shelter, Integer> {
     Optional<Shelter> findByAccountId(Integer accountId);
+
+    @Query("select s.id " +
+        "from Shelter s " +
+        "where s.kakaoLocationId " +
+        "in :shelterLocationIdList")
+    List<Shelter> findAllByKakaoLocationIdIn(List<Integer> shelterLocationIdList);
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
@@ -2,10 +2,13 @@ package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.common.error.exception.NotFound404;
 import com.daggle.animory.domain.pet.repository.PetRepository;
+import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,5 +23,12 @@ public class ShelterService {
                         () -> new NotFound404("해당하는 보호소가 존재하지 않습니다.")),
                 petRepository.findByShelterId(shelterId, PageRequest.of(page, 10))
         );
+    }
+
+    public List<ShelterLocationDto> filterExistShelterListByLocationId(final List<Integer> shelterLocationIdList) {
+        return shelterRepository.findAllByKakaoLocationIdIn(shelterLocationIdList)
+                .stream()
+                .map(ShelterLocationDto::of)
+                .toList();
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/ShelterLocationDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/ShelterLocationDto.java
@@ -1,0 +1,27 @@
+package com.daggle.animory.domain.shelter.dto.response;
+
+import com.daggle.animory.domain.shelter.entity.Shelter;
+import lombok.Getter;
+
+@Getter
+public record ShelterLocationDto(
+    Integer id,
+    String name,
+    String contact,
+    Integer kakaoLocationId,
+    double x,
+    double y
+
+) {
+
+    public static ShelterLocationDto of(final Shelter shelter) {
+        return new ShelterLocationDto(
+            shelter.getId(),
+            shelter.getName(),
+            shelter.getContact(),
+            shelter.getAddress().getKakaoLocationId(),
+            shelter.getAddress().getX(),
+            shelter.getAddress().getY()
+        );
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/ShelterLocationDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/ShelterLocationDto.java
@@ -1,9 +1,7 @@
 package com.daggle.animory.domain.shelter.dto.response;
 
 import com.daggle.animory.domain.shelter.entity.Shelter;
-import lombok.Getter;
 
-@Getter
 public record ShelterLocationDto(
     Integer id,
     String name,

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/ShelterAddress.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/ShelterAddress.java
@@ -12,6 +12,14 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ShelterAddress {
 
+    // 카카오 API에서 제공하는 주소 ID
+    // kakao Id와 x, y 좌표는 가입 프로세스가 자동화 된다면 @NotNull이 될 수 있음.
+    private Integer kakaoLocationId;
+
+    private double x;
+
+    private double y;
+
     @NotNull
     private Province province;
 

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterControllerTest.java
@@ -9,10 +9,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
 import javax.validation.constraints.Min;
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Import(ShelterController.class)
 public class ShelterControllerTest extends BaseWebMvcTest {
@@ -47,5 +50,15 @@ public class ShelterControllerTest extends BaseWebMvcTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false));
         }
+    }
+
+    @Test
+    void 보호소_위치_필터링() throws Exception {
+        mvc.perform(post("/shelter/filter")
+                .contentType("application/json")
+                .content( om.writeValueAsBytes( List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) ) ))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(print());
     }
 }


### PR DESCRIPTION
## 작업 내용
- ShelterAddress에 kakaoLocationId와 x, y 좌표 필드를 추가하였습니다. 현재 수동등록을 전제로 하고 있기 때문에 `@NotNull` 은 생략하였습니다.
- Integer List를 입력받아서, Shelter 중에 location Id 가 일치하는 목록을 Shelter 정보와 함께 리스트로 반환합니다.

## 기타
- 수동 등록을 전제로 하기 때문에, 프론트엔드 팀의 테스트를 위해서도 재배포에 영향을 받지 않는 DB 서버를 구축할 필요가 있을 것 같습니다.
- Service, Repository Layer의 테스트는 다음 이슈에서 같이 작성하겠습니다.


Close #132 