### PR TITLE
이메일 빈칸 입력을 막기 위한 @NotBlank 추가

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/request/AccountLoginDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/request/AccountLoginDto.java
@@ -3,11 +3,12 @@ package com.daggle.animory.domain.account.dto.request;
 import lombok.Builder;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Builder
 public record AccountLoginDto(
         @Email(message = "이메일 형식에 맞지 않습니다.")
-        @NotNull(message = "이메일을 입력해주세요.") String email,
+        @NotBlank(message = "이메일을 입력해주세요.") String email,
         @NotNull(message = "비밀번호를 입력해주세요.") String password) {
 }

--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/request/EmailValidateDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/request/EmailValidateDto.java
@@ -2,9 +2,9 @@ package com.daggle.animory.domain.account.dto.request;
 
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 
 public record EmailValidateDto(
-        @NotNull(message = "이메일을 입력해주세요.")
+        @NotBlank(message = "이메일을 입력해주세요.")
         @Email(message = "이메일 형식에 맞지 않습니다.") String email) {
 }

--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/request/ShelterSignUpDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/request/ShelterSignUpDto.java
@@ -9,11 +9,14 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+
 @Builder
 public record ShelterSignUpDto(
-        @Email(message = "이메일 형식에 맞지 않습니다.") String email,
+        @Email(message = "이메일 형식에 맞지 않습니다.")
+        @NotBlank(message = "이메일을 입력해주세요.") String email,
         @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&+=!])(?!.*\\s).{8,20}$",
                 message = "비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호여야 합니다.") String password,
         @NotNull(message = "보호소 이름을 입력해주세요.") String name,


### PR DESCRIPTION
## 작업 내용
- 이메일 빈칸 입력을 막기 위해 @NotNull에서 @NotBlank 으로 변경

## 공유하고 싶은 내용
- @ NotNull -> Null만 허용하지 않음
- @ NotEmpty -> null 과 "" 은 허용 X, " " 은 허용
- @ NotBlank -> null 과 "" 과 " " 모두 허용 X

Close #147 