### PR TITLE
보호소 정보 수정 API 추가

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterController.java
@@ -1,6 +1,9 @@
 package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.common.Response;
+import com.daggle.animory.common.security.RequireRole;
+import com.daggle.animory.domain.account.entity.Account;
+import com.daggle.animory.domain.account.entity.AccountRole;
 import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
@@ -25,13 +28,16 @@ public class ShelterController {
         return Response.success(shelterService.getShelterProfile(shelterId, page));
     }
 
+    @RequireRole(AccountRole.SHELTER)
     @PutMapping("/{shelterId}")
-    public Response<ShelterUpdateSuccessDto> updateShelter(@PathVariable @Min(0) final Integer shelterId,
+    public Response<ShelterUpdateSuccessDto> updateShelter(final Account account,
+                                                           @PathVariable @Min(0) final Integer shelterId,
                                                            @RequestBody final ShelterUpdateDto shelterUpdateDto) {
-        return Response.success(shelterService.updateShelterInfo(shelterId, shelterUpdateDto));
+        return Response.success(shelterService.updateShelterInfo(account, shelterId, shelterUpdateDto));
     }
 
-    /** 등록된 보호소 필터링 API <br>
+    /**
+     * 등록된 보호소 필터링 API <br>
      * 리스트 형태의 보호소 정보를 입력받아서, DB에서 kakaoLocationId가 일치하는 Shelter목록을 반환한다.
      */
     @PostMapping("/filter")

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterController.java
@@ -1,8 +1,10 @@
 package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.common.Response;
+import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
+import com.daggle.animory.domain.shelter.dto.response.ShelterUpdateSuccessDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +23,12 @@ public class ShelterController {
     public Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) final Integer shelterId,
                                                    @RequestParam("page") @Min(0) final int page) {
         return Response.success(shelterService.getShelterProfile(shelterId, page));
+    }
+
+    @PutMapping("/{shelterId}")
+    public Response<ShelterUpdateSuccessDto> updateShelter(@PathVariable @Min(0) final Integer shelterId,
+                                                           @RequestBody final ShelterUpdateDto shelterUpdateDto) {
+        return Response.success(shelterService.updateShelterInfo(shelterId, shelterUpdateDto));
     }
 
     /** 등록된 보호소 필터링 API <br>

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
@@ -12,6 +12,7 @@ import com.daggle.animory.domain.shelter.entity.Shelter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -37,6 +38,7 @@ public class ShelterService {
                 .toList();
     }
 
+    @Transactional
     public ShelterUpdateSuccessDto updateShelterInfo(Account account, Integer shelterId, ShelterUpdateDto shelterUpdateDto) {
         Shelter shelter = shelterRepository.findById(shelterId).orElseThrow(
                 () -> new NotFound404("해당하는 보호소가 존재하지 않습니다.")

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
@@ -2,8 +2,11 @@ package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.common.error.exception.NotFound404;
 import com.daggle.animory.domain.pet.repository.PetRepository;
+import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
+import com.daggle.animory.domain.shelter.dto.response.ShelterUpdateSuccessDto;
+import com.daggle.animory.domain.shelter.entity.Shelter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -30,5 +33,17 @@ public class ShelterService {
                 .stream()
                 .map(ShelterLocationDto::of)
                 .toList();
+    }
+
+    public ShelterUpdateSuccessDto updateShelterInfo(Integer shelterId, ShelterUpdateDto shelterUpdateDto) {
+        Shelter shelter = shelterRepository.findById(shelterId).orElseThrow(
+                () -> new NotFound404("해당하는 보호소가 존재하지 않습니다.")
+        );
+
+        shelter.updateInfo(shelterUpdateDto);
+
+        return ShelterUpdateSuccessDto.builder()
+                .shelterId(shelterId)
+                .build();
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
@@ -1,6 +1,8 @@
 package com.daggle.animory.domain.shelter;
 
+import com.daggle.animory.common.error.exception.Forbidden403;
 import com.daggle.animory.common.error.exception.NotFound404;
+import com.daggle.animory.domain.account.entity.Account;
 import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
@@ -35,10 +37,14 @@ public class ShelterService {
                 .toList();
     }
 
-    public ShelterUpdateSuccessDto updateShelterInfo(Integer shelterId, ShelterUpdateDto shelterUpdateDto) {
+    public ShelterUpdateSuccessDto updateShelterInfo(Account account, Integer shelterId, ShelterUpdateDto shelterUpdateDto) {
         Shelter shelter = shelterRepository.findById(shelterId).orElseThrow(
                 () -> new NotFound404("해당하는 보호소가 존재하지 않습니다.")
         );
+
+        if (!shelter.getAccount().getEmail().equals(account.getEmail())) {
+            throw new Forbidden403("보호소 정보를 수정할 권한이 없습니다.");
+        }
 
         shelter.updateInfo(shelterUpdateDto);
 

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
@@ -42,7 +42,7 @@ public class ShelterService {
                 () -> new NotFound404("해당하는 보호소가 존재하지 않습니다.")
         );
 
-        if (!shelter.getAccount().getEmail().equals(account.getEmail())) {
+        if (!shelter.getAccount().getId().equals(account.getId())) {
             throw new Forbidden403("보호소 정보를 수정할 권한이 없습니다.");
         }
 

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/dto/request/ShelterAddressUpdateDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/dto/request/ShelterAddressUpdateDto.java
@@ -1,0 +1,22 @@
+package com.daggle.animory.domain.shelter.dto.request;
+
+import com.daggle.animory.domain.shelter.entity.Province;
+import com.daggle.animory.domain.shelter.entity.ShelterAddress;
+import lombok.Builder;
+
+import javax.validation.constraints.NotNull;
+@Builder
+public record ShelterAddressUpdateDto(
+        @NotNull(message = "광역시/도를 입력해주세요.") Province province,
+        @NotNull(message = "시/군/구를 입력해주세요.") String city,
+        @NotNull(message = "도로명을 입력해주세요.") String roadName,
+        String detail) {
+    public ShelterAddress getShelterAddress() {
+        return ShelterAddress.builder()
+                .province(province)
+                .city(city)
+                .roadName(roadName)
+                .detail(detail)
+                .build();
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/dto/request/ShelterUpdateDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/dto/request/ShelterUpdateDto.java
@@ -1,0 +1,12 @@
+package com.daggle.animory.domain.shelter.dto.request;
+
+import lombok.Builder;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+@Builder
+public record ShelterUpdateDto(
+        @NotNull(message = "보호소 이름을 입력해주세요.") String name,
+        @NotNull(message = "보호소 연락처를 입력해주세요.") String contact,
+        @Valid @NotNull(message = "보호소 주소를 입력해주세요.") ShelterAddressUpdateDto shelterAddressUpdateDto) {
+}

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/ShelterUpdateSuccessDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/ShelterUpdateSuccessDto.java
@@ -1,0 +1,15 @@
+package com.daggle.animory.domain.shelter.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ShelterUpdateSuccessDto {
+    private final String message = "수정이 완료되었습니다.";
+    private final Integer shelterId;
+
+    @Builder
+    public ShelterUpdateSuccessDto(final Integer shelterId) {
+        this.shelterId = shelterId;
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Shelter.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Shelter.java
@@ -2,6 +2,7 @@ package com.daggle.animory.domain.shelter.entity;
 
 import com.daggle.animory.common.entity.BaseEntity;
 import com.daggle.animory.domain.account.entity.Account;
+import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
 import lombok.*;
 
 import javax.persistence.*;
@@ -29,4 +30,10 @@ public class Shelter extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "account_id")
     private Account account;
+
+    public void updateInfo(ShelterUpdateDto shelterUpdateDto) {
+        this.name = shelterUpdateDto.name();
+        this.contact = shelterUpdateDto.contact();
+        this.address = shelterUpdateDto.shelterAddressUpdateDto().getShelterAddress();
+    }
 }

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
@@ -1,11 +1,13 @@
 package com.daggle.animory.domain.shelter;
 
+import com.daggle.animory.domain.account.entity.Account;
 import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetType;
 import com.daggle.animory.domain.shelter.dto.request.ShelterAddressUpdateDto;
 import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterUpdateSuccessDto;
 import com.daggle.animory.domain.shelter.entity.Province;
+import com.daggle.animory.testutil.fixture.AccountFixture;
 import com.daggle.animory.testutil.fixture.PetFixture;
 import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
@@ -23,6 +25,7 @@ import org.springframework.data.domain.PageImpl;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,8 +78,11 @@ public class ShelterServiceTest {
     class 보호소_수정 {
         @Test
         void 성공_보호소_수정() {
+            Account account = AccountFixture.getShelter();
+
             Shelter shelter = Shelter.builder()
                     .id(1)
+                    .account(account)
                     .build();
 
             ShelterUpdateDto shelterUpdateDto = ShelterUpdateDto.builder()
@@ -92,11 +98,13 @@ public class ShelterServiceTest {
             // stub
             Mockito.when(shelterRepository.findById(any())).thenReturn(Optional.of(shelter));
 
-            ShelterUpdateSuccessDto shelterUpdateSuccessDto = shelterService.updateShelterInfo(shelter.getId(), shelterUpdateDto);
+            ShelterUpdateSuccessDto shelterUpdateSuccessDto = shelterService.updateShelterInfo(account, shelter.getId(), shelterUpdateDto);
 
-            assertThat(shelterUpdateSuccessDto.getShelterId()).isEqualTo(shelter.getId());
-            assertThat(shelter.getName()).isEqualTo(shelterUpdateDto.name());
-            assertThat(shelter.getAddress().getCity()).isEqualTo(shelterUpdateDto.shelterAddressUpdateDto().city());
+            assertAll(
+                    () -> assertThat(shelterUpdateSuccessDto.getShelterId()).isEqualTo(shelter.getId()),
+                    () -> assertThat(shelter.getName()).isEqualTo(shelterUpdateDto.name()),
+                    () -> assertThat(shelter.getAddress().getCity()).isEqualTo(shelterUpdateDto.shelterAddressUpdateDto().city())
+            );
         }
     }
 }

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
@@ -2,6 +2,10 @@ package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.shelter.dto.request.ShelterAddressUpdateDto;
+import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
+import com.daggle.animory.domain.shelter.dto.response.ShelterUpdateSuccessDto;
+import com.daggle.animory.domain.shelter.entity.Province;
 import com.daggle.animory.testutil.fixture.PetFixture;
 import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
@@ -22,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
-public class ShelterServiceTest  {
+public class ShelterServiceTest {
     @InjectMocks
     private ShelterService shelterService;
     @Mock
@@ -64,6 +68,35 @@ public class ShelterServiceTest  {
 
             assertThat(shelterProfilePage.shelter().id()).isEqualTo(shelter.getId());
             assertThat(shelterProfilePage.petList().getPets()).isEmpty();
+        }
+    }
+
+    @Nested
+    class 보호소_수정 {
+        @Test
+        void 성공_보호소_수정() {
+            Shelter shelter = Shelter.builder()
+                    .id(1)
+                    .build();
+
+            ShelterUpdateDto shelterUpdateDto = ShelterUpdateDto.builder()
+                    .contact("0101010101")
+                    .name("변경한 이름")
+                    .shelterAddressUpdateDto(ShelterAddressUpdateDto.builder()
+                            .province(Province.광주)
+                            .city("변경한 시")
+                            .roadName("변경한 도로명 주소")
+                            .build())
+                    .build();
+
+            // stub
+            Mockito.when(shelterRepository.findById(any())).thenReturn(Optional.of(shelter));
+
+            ShelterUpdateSuccessDto shelterUpdateSuccessDto = shelterService.updateShelterInfo(shelter.getId(), shelterUpdateDto);
+
+            assertThat(shelterUpdateSuccessDto.getShelterId()).isEqualTo(shelter.getId());
+            assertThat(shelter.getName()).isEqualTo(shelterUpdateDto.name());
+            assertThat(shelter.getAddress().getCity()).isEqualTo(shelterUpdateDto.shelterAddressUpdateDto().city());
         }
     }
 }

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
@@ -82,7 +82,9 @@ public class ShelterServiceTest {
     class 보호소_수정 {
         @Test
         void 성공_보호소_수정() {
-            Account account = AccountFixture.getShelter();
+            Account account = Account.builder()
+                    .id(1)
+                    .build();
 
             Shelter shelter = Shelter.builder()
                     .id(1)
@@ -113,11 +115,17 @@ public class ShelterServiceTest {
 
         @Test
         void 실패_보호소_수정_권한없음() {
-            List<Account> accounts = AccountFixture.get(2, AccountRole.SHELTER);
+            Account account = Account.builder()
+                    .id(1)
+                    .build();
+
+            Account otherAccount = Account.builder()
+                    .id(2)
+                    .build();
 
             Shelter shelter = Shelter.builder()
                     .id(1)
-                    .account(accounts.get(0))
+                    .account(account)
                     .build();
 
             ShelterUpdateDto shelterUpdateDto = ShelterUpdateDto.builder()
@@ -133,7 +141,7 @@ public class ShelterServiceTest {
             // stub
             Mockito.when(shelterRepository.findById(any())).thenReturn(Optional.of(shelter));
 
-            assertThatThrownBy(() -> shelterService.updateShelterInfo(accounts.get(1), shelter.getId(), shelterUpdateDto))
+            assertThatThrownBy(() -> shelterService.updateShelterInfo(otherAccount, shelter.getId(), shelterUpdateDto))
                     .isInstanceOf(Forbidden403.class)
                     .hasMessage("보호소 정보를 수정할 권한이 없습니다.");
         }

--- a/animory/src/test/java/com/daggle/animory/testutil/fixture/AccountFixture.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/fixture/AccountFixture.java
@@ -15,6 +15,7 @@ public class AccountFixture {
 
     public static Account getUser() {
         return Account.builder()
+                .id(1)
                 .email(EMAIL)
                 .password(encodedPassword)
                 .role(AccountRole.USER)
@@ -23,6 +24,7 @@ public class AccountFixture {
 
     public static Account getShelter() {
         return Account.builder()
+                .id(2)
                 .email(EMAIL)
                 .password(encodedPassword)
                 .role(AccountRole.SHELTER)
@@ -35,6 +37,7 @@ public class AccountFixture {
         for (int i = 0; i < n; i++) {
             accounts.add(
                     Account.builder()
+                            .id(i + 1)
                             .email(i + EMAIL)
                             .password(PASSWORD)
                             .role(role)

--- a/animory/src/test/java/com/daggle/animory/testutil/fixture/AccountFixture.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/fixture/AccountFixture.java
@@ -15,7 +15,6 @@ public class AccountFixture {
 
     public static Account getUser() {
         return Account.builder()
-                .id(1)
                 .email(EMAIL)
                 .password(encodedPassword)
                 .role(AccountRole.USER)
@@ -24,7 +23,6 @@ public class AccountFixture {
 
     public static Account getShelter() {
         return Account.builder()
-                .id(2)
                 .email(EMAIL)
                 .password(encodedPassword)
                 .role(AccountRole.SHELTER)
@@ -37,7 +35,6 @@ public class AccountFixture {
         for (int i = 0; i < n; i++) {
             accounts.add(
                     Account.builder()
-                            .id(i + 1)
                             .email(i + EMAIL)
                             .password(PASSWORD)
                             .role(role)


### PR DESCRIPTION
## 작업 내용
- 보호소 정보 수정 API를 구현하였습니다.
- 서비스단 테스트 코드를 작성하였습니다. 

## 기타
- 수정 요청 시 기존 보호소 정보 전체를 덮어 씁니다.

Close #143 