### PR TITLE
Jacoco Test Coverage PR actions 개선

### DIFF
--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -62,5 +62,6 @@ jobs:
           update-comment: true
           pass-emoji: ':heart_eyes:'
           fail-emoji: ':disappointed:'
-          min-coverage-overall: 60
+          skip-if-no-changes: true
+          min-coverage-overall: 70
           min-coverage-changed-files: 50

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -58,5 +58,9 @@ jobs:
           paths: |
             ${{ github.workspace }}/animory/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 50
+          title: 'Test Coverage Report'
+          update-comment: true
+          pass-emoji: ':heart_eyes:'
+          fail-emoji: ':disappointed:'
+          min-coverage-overall: 60
           min-coverage-changed-files: 50

--- a/animory/build.gradle
+++ b/animory/build.gradle
@@ -80,4 +80,12 @@ jacocoTestReport {
 		html.required = true
 		html.destination file("${buildDir}/reports/jacocoReport")
 	}
+	
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [ // 테스트 커버리지 측정에서 제외할 파일
+					"com/daggle/animory/AnimoryApplication.class",
+			])
+		}))
+	}
 }


### PR DESCRIPTION
## 작업 내용

- `update-comment` 를 true로 변경하였습니다. 새로운 report가 생성될 때(열려있는 PR에 추가 push발생 시), 코멘트를 계속 추가해 나가지 않고 기존의 코멘트를 업데이트합니다.
- `skip-if-no-changes`를 true로 변경합니다. 변경된 파일에 대한 정보가 없으면 설명이 추가되지 않습니다.
- `pass-emoji`와 `fail-emoji`를 변경했습니다. 😍 , 😞 

- 기본적인 테스트 코드가 충분히 많아진 상태이므로 **전체 프로젝트 코드의 테스트 커버리지 통과기준을 70%로 수정하였습니다.**

- 테스트 커버리지 계산 시 SpringBoot Main Application 파일을 제외시켰습니다.

<br><br>

## 공유할 사항

- 보고서에 음수로 표시되는 값에 대해서 잘 이해를 못하겠습니다. 
- 참고 이슈: https://github.com/Madrapps/jacoco-report/issues/69


<br><br>

## 참고
- https://github.com/marketplace/actions/jacoco-report
- https://www.baeldung.com/jacoco-report-exclude

Close #153 