### PR TITLE
편리한 로그인 UX를 위한 토큰 만료 시점 조정

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
@@ -75,15 +75,17 @@ public class TokenProvider {
     }
 
     private Date calcExpirationDateTime() {
-        final LocalDateTime currentTime = LocalDateTime.now();
+        final LocalDateTime currentTime = LocalDateTime.now(); // 현재 시각으로 부터
 
         final LocalDateTime expirationDateTime = currentTime
-            .plusDays(TOKEN_EXPIRATION_DATE_TO_PLUS)
-            .withHour(TOKEN_EXPIRATION_FIXED_HOUR)
-            .withMinute(0)
-            .withSecond(0);
+            .plusDays(TOKEN_EXPIRATION_DATE_TO_PLUS) // day를 더하고
+            .withHour(TOKEN_EXPIRATION_FIXED_HOUR); // 고정된 시각
 
-        return Date.from(expirationDateTime.atZone(java.time.ZoneId.systemDefault()).toInstant());
+        return convertLocalDateTimeToDate(expirationDateTime);
+    }
+
+    private Date convertLocalDateTimeToDate(final LocalDateTime localDateTime) {
+        return Date.from(localDateTime.atZone(java.time.ZoneId.systemDefault()).toInstant());
     }
 
 

--- a/animory/src/main/resources/application-production.yml
+++ b/animory/src/main/resources/application-production.yml
@@ -43,9 +43,7 @@ springdoc.swagger-ui:
   tags-sorter: alpha # 태그를 알파벳 순으로 정렬합니다.
 
 # Security
-jwt:
-  secret: ${JWT_SECRET}
-  token-validity-in-seconds: "#{60 * 60 * 24}"
+jwt.secret: ${JWT_SECRET}
 
 # AWS S3
 cloud:

--- a/animory/src/main/resources/application.yml
+++ b/animory/src/main/resources/application.yml
@@ -52,8 +52,6 @@ springdoc.swagger-ui:
     tags-sorter: alpha # 태그를 알파벳 순으로 정렬합니다.
 
 # Security
-jwt:
-  secret: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK
-  token-validity-in-seconds: "#{60 * 60 * 24}"
+jwt.secret: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK
 
 

--- a/animory/src/test/java/com/daggle/animory/common/security/TokenProviderTest.java
+++ b/animory/src/test/java/com/daggle/animory/common/security/TokenProviderTest.java
@@ -1,0 +1,41 @@
+package com.daggle.animory.common.security;
+
+import com.daggle.animory.domain.account.entity.AccountRole;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = TokenProvider.class)
+class TokenProviderTest {
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Test
+    void 토큰_만료기한이_올바르게_설정되는지_검사() throws JSONException {
+        final LocalDateTime now = LocalDateTime.now();
+        final String token = tokenProvider.create("test@gmail.com", AccountRole.SHELTER);
+
+        final String decodedToken = new String(java.util.Base64.getDecoder().decode(token.split("\\.")[1]));
+        final String expirationTimeOfToken = new JSONObject(decodedToken).get("exp").toString();
+
+        final LocalDateTime expectedExpirationTime = LocalDateTime
+            .ofInstant(
+                Instant.ofEpochSecond(Long.parseLong(expirationTimeOfToken)),
+                java.time.ZoneId.systemDefault()
+            );
+
+        assertThat(now.plusDays(1).withHour(3).truncatedTo(ChronoUnit.MINUTES))
+            .isEqualTo(expectedExpirationTime);
+    }
+
+
+}


### PR DESCRIPTION
## 작업 내용
- 토큰 만료 시점을 현재 시각으로부터 하루를 더한 날짜의 오전 3시로 설정하였습니다.
- 테스트 코드 추가하였습니다.

Close #158 