### PR TITLE
주소 입력시, "제주특별자치도" 등의 Table Enum에 없는 문자열 처리, City Null 허용

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/request/ShelterAddressSignUpDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/request/ShelterAddressSignUpDto.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.NotNull;
 @Builder
 public record ShelterAddressSignUpDto(
         @NotNull(message = "광역시/도를 입력해주세요.") Province province,
-        @NotNull(message = "시/군/구를 입력해주세요.") String city,
+        String city,
         @NotNull(message = "도로명을 입력해주세요.") String roadName,
         String detail) {
     public ShelterAddress getShelterAddress() {

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/dto/request/ShelterAddressUpdateDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/dto/request/ShelterAddressUpdateDto.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotNull;
 @Builder
 public record ShelterAddressUpdateDto(
         @NotNull(message = "광역시/도를 입력해주세요.") Province province,
-        @NotNull(message = "시/군/구를 입력해주세요.") String city,
+        String city,
         @NotNull(message = "도로명을 입력해주세요.") String roadName,
         String detail) {
     public ShelterAddress getShelterAddress() {

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Province.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Province.java
@@ -8,18 +8,19 @@ public enum Province {
     광주,
     대전,
     울산,
-    세종,
+    세종특별자치시,
     경기,
-    강원,
+    강원특별자치도,
     충북,
     충남,
     전북,
     전남,
     경북,
     경남,
-    제주;
+    제주특별자치도
+    ;
 
-    public String getFullProvinceName() {
+    public String getProvinceNameForUI() {
         return switch (this) {
             case 서울 -> "서울특별시";
             case 부산 -> "부산광역시";
@@ -28,16 +29,16 @@ public enum Province {
             case 광주 -> "광주광역시";
             case 대전 -> "대전광역시";
             case 울산 -> "울산광역시";
-            case 세종 -> "세종특별자치시";
+            case 세종특별자치시 -> "세종시";
             case 경기 -> "경기도";
-            case 강원 -> "강원특별자치도";
+            case 강원특별자치도 -> "강원도";
             case 충북 -> "충청북도";
             case 충남 -> "충청남도";
             case 전북 -> "전라북도";
             case 전남 -> "전라남도";
             case 경북 -> "경상북도";
             case 경남 -> "경상남도";
-            case 제주 -> "제주특별자치도";
+            case 제주특별자치도 -> "제주도";
         };
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Province.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Province.java
@@ -30,7 +30,7 @@ public enum Province {
             case 울산 -> "울산광역시";
             case 세종 -> "세종특별자치시";
             case 경기 -> "경기도";
-            case 강원 -> "강원도";
+            case 강원 -> "강원특별자치도";
             case 충북 -> "충청북도";
             case 충남 -> "충청남도";
             case 전북 -> "전라북도";

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
@@ -34,6 +34,6 @@ public class ShortFormService {
 
 
     private String buildCategoryPageTitle(final ShortFormSearchCondition searchCondition) {
-        return searchCondition.area().getFullProvinceName() + " 기준 " + searchCondition.type().getKoreanName() + " 친구들";
+        return searchCondition.area().getProvinceNameForUI() + " 기준 " + searchCondition.type().getKoreanName() + " 친구들";
     }
 }

--- a/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
@@ -130,8 +130,8 @@ public class AccountControllerTest extends BaseWebMvcTest {
                     .contact("01012345678")
                     .zonecode("3143")
                     .address(ShelterAddressSignUpDto.builder()
-                            .province(Province.광주)
-                            .city(null)
+                            .province(null)
+                            .city(null) // city는 null 허용
                             .roadName("용봉동")
                             .detail("전남대")
                             .build())


### PR DESCRIPTION
## 작업 내용
- Province의 Enum value 자체를 변경하였습니다.
  - 제주 -> 제주특별자치도
  - 세종 -> 세종특별자치시
  - 강원 -> 강원특별자치도

- City에 Null이 들어가는 경우를 허용하였습니다.
  - ( 예시: "세종특별자치시 전의면 가나물길 13")
  - Daum Postcode Service 기준, Province와 도로명주소로만 구성되어 있음.)




Close #155 