### PR TITLE
AOP 기반 권한 인증 제거

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/security/UserDetailsImpl.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/UserDetailsImpl.java
@@ -14,6 +14,10 @@ import java.util.stream.Collectors;
 public class UserDetailsImpl implements UserDetails {
     private final Account account;
 
+    public String getEmail() {
+        return account.getEmail();
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Arrays.stream(account.getRole().toString().split(",")).map(SimpleGrantedAuthority::new).collect(Collectors.toList());

--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
@@ -1,9 +1,7 @@
 package com.daggle.animory.domain.pet.controller;
 
 import com.daggle.animory.common.Response;
-import com.daggle.animory.common.security.RequireRole;
-import com.daggle.animory.domain.account.entity.Account;
-import com.daggle.animory.domain.account.entity.AccountRole;
+import com.daggle.animory.common.security.UserDetailsImpl;
 import com.daggle.animory.domain.pet.dto.request.PetRegisterRequestDto;
 import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
 import com.daggle.animory.domain.pet.dto.response.*;
@@ -15,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -28,34 +27,31 @@ public class PetController implements PetControllerApi {
     private final PetWriteService petWriteService;
 
     // Pet 등록
-    @RequireRole(AccountRole.SHELTER)
     @PostMapping(value = "", consumes = {"multipart/form-data"})
     public Response<RegisterPetSuccessDto> registerPet(
-        final Account account,
+        @AuthenticationPrincipal final UserDetailsImpl userDetails,
         @RequestPart(value = "petInfo") final PetRegisterRequestDto petRegisterRequestDto,
         @RequestPart(value = "profileImage") final MultipartFile image,
         @RequestPart(value = "profileVideo") final MultipartFile video
     ) {
 
         return Response.success(
-            petWriteService.registerPet(account, petRegisterRequestDto, image, video));
+            petWriteService.registerPet(userDetails, petRegisterRequestDto, image, video));
     }
 
     // Pet 수정 페이지에서, 기존 등록된 정보를 확인하기 위해 호출하는 API
-    @RequireRole(AccountRole.SHELTER)
     @GetMapping(value = "/register-info/{petId}")
-    public Response<PetRegisterInfoDto> getPetRegisterInfo(final Account account,
+    public Response<PetRegisterInfoDto> getPetRegisterInfo(@AuthenticationPrincipal final UserDetailsImpl userDetails,
                                                            @PathVariable final int petId) {
 
         return Response.success(
-            petReadService.getRegisterInfo(account, petId));
+            petReadService.getRegisterInfo(userDetails, petId));
     }
 
     // Pet 수정 요청
-    @RequireRole(AccountRole.SHELTER)
     @PatchMapping(value = "/{petId}", consumes = {"multipart/form-data"})
     public Response<UpdatePetSuccessDto> updatePet(
-        final Account account,
+        @AuthenticationPrincipal final UserDetailsImpl userDetails,
         @PathVariable final int petId,
         @RequestPart(value = "petInfo") final PetUpdateRequestDto petUpdateRequestDto,
         @RequestPart(value = "profileImage", required = false) final MultipartFile image,
@@ -63,9 +59,8 @@ public class PetController implements PetControllerApi {
     ) {
 
         return Response.success(
-            petWriteService.updatePet(account, petId, petUpdateRequestDto, image, video));
+            petWriteService.updatePet(userDetails, petId, petUpdateRequestDto, image, video));
     }
-
 
     // Pagination이 아닌, 각 8개씩 반환합니다. 이후 더보기 버튼을 통해 다른 API를 호출되는 시나리오 입니다.
     @GetMapping("/profiles")
@@ -92,10 +87,9 @@ public class PetController implements PetControllerApi {
 
     // Pet 입양 완료 상태 등록
     @PostMapping("/adoption/{petId}")
-    @RequireRole(AccountRole.SHELTER)
-    public Response<Void> updatePetAdopted(final Account account,
+    public Response<Void> updatePetAdopted(@AuthenticationPrincipal final UserDetailsImpl userDetails,
                                            @PathVariable final int petId) {
-        petWriteService.updatePetAdopted(account, petId);
+        petWriteService.updatePetAdopted(userDetails, petId);
         return Response.success();
     }
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
@@ -1,7 +1,7 @@
 package com.daggle.animory.domain.pet.controller;
 
 import com.daggle.animory.common.Response;
-import com.daggle.animory.domain.account.entity.Account;
+import com.daggle.animory.common.security.UserDetailsImpl;
 import com.daggle.animory.domain.pet.dto.request.PetRegisterRequestDto;
 import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
 import com.daggle.animory.domain.pet.dto.response.*;
@@ -20,7 +20,7 @@ public interface PetControllerApi {
     @Operation(summary = "Pet 등록 요청",
         description = "Pet 등록 요청 API 입니다. 보호소 계정 권한이 필요합니다.")
     Response<RegisterPetSuccessDto> registerPet(
-        Account account,
+         UserDetailsImpl userDetails,
         @RequestPart(value = "petInfo") PetRegisterRequestDto petRegisterRequestDto,
         @RequestPart(value = "profileImage") MultipartFile image,
         @RequestPart(value = "profileVideo") MultipartFile video
@@ -28,14 +28,14 @@ public interface PetControllerApi {
 
     @Operation(summary = "Pet 수정 페이지 진입, 기존 펫 정보 확인",
         description = "Pet 수정 페이지에서, 기존 등록된 정보를 확인하기 위해 호출하는 API 입니다. 보호소 계정 권한이 필요합니다.")
-    Response<PetRegisterInfoDto> getPetRegisterInfo(Account account,
+    Response<PetRegisterInfoDto> getPetRegisterInfo(UserDetailsImpl userDetails,
                                                     @PathVariable int petId);
 
     // Pet 수정 요청
     @Operation(summary = "Pet 수정 요청",
         description = "보호소 계정 권한이 필요합니다.")
     Response<UpdatePetSuccessDto> updatePet(
-        Account account,
+            UserDetailsImpl userDetails,
         @PathVariable int petId,
         @RequestPart(value = "petInfo") PetUpdateRequestDto petUpdateRequestDto,
         @RequestPart(value = "profileImage", required = false) MultipartFile image,

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
@@ -2,7 +2,7 @@ package com.daggle.animory.domain.pet.service;
 
 
 import com.daggle.animory.common.error.exception.NotFound404;
-import com.daggle.animory.domain.account.entity.Account;
+import com.daggle.animory.common.security.UserDetailsImpl;
 import com.daggle.animory.domain.pet.dto.response.*;
 import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.repository.PetRepository;
@@ -58,14 +58,14 @@ public class PetReadService {
 
 
     // 기존의 펫 등록 정보 조회
-    public PetRegisterInfoDto getRegisterInfo(final Account account,
+    public PetRegisterInfoDto getRegisterInfo(final UserDetailsImpl userDetails,
                                               final int petId) {
 
         // 펫 id로 Pet, PetPolygonProfile 얻어오기
         final Pet registerPet = petRepository.findById(petId)
             .orElseThrow(() -> new NotFound404("등록되지 않은 펫입니다."));
 
-        petValidator.validatePetUpdateAuthority(account, registerPet);
+        petValidator.validatePetUpdateAuthority(userDetails.getUsername(), registerPet);
 
         // Pet -> PetRegisterInfoDto
         return PetRegisterInfoDto.fromEntity(registerPet);

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
@@ -65,7 +65,7 @@ public class PetReadService {
         final Pet registerPet = petRepository.findById(petId)
             .orElseThrow(() -> new NotFound404("등록되지 않은 펫입니다."));
 
-        petValidator.validatePetUpdateAuthority(userDetails.getUsername(), registerPet);
+        petValidator.validatePetUpdateAuthority(userDetails.getEmail(), registerPet);
 
         // Pet -> PetRegisterInfoDto
         return PetRegisterInfoDto.fromEntity(registerPet);

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetValidator.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetValidator.java
@@ -26,11 +26,11 @@ public class PetValidator {
      * 요청받은 계정에 연결된 보호소가 같은지 확인합니다.
      * </pre>
      */
-    public void validatePetUpdateAuthority(final Account account,
+    public void validatePetUpdateAuthority(final String email,
                                            final Pet pet){
 
         // Data Integrity Validation
-        final Shelter shelterFromRequest = shelterRepository.findByAccountId(account.getId())
+        final Shelter shelterFromRequest = shelterRepository.findByAccount_Email(email)
             .orElseThrow(() -> new NotFound404("보호소 정보가 존재하지 않습니다."));
         final Shelter shelterToUpdate = pet.getShelter();
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetValidator.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetValidator.java
@@ -30,7 +30,7 @@ public class PetValidator {
                                            final Pet pet){
 
         // Data Integrity Validation
-        final Shelter shelterFromRequest = shelterRepository.findByAccount_Email(email)
+        final Shelter shelterFromRequest = shelterRepository.findByAccountEmail(email)
             .orElseThrow(() -> new NotFound404("보호소 정보가 존재하지 않습니다."));
         final Shelter shelterToUpdate = pet.getShelter();
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
@@ -41,7 +41,7 @@ public class PetWriteService {
         final URL videoUrl = fileRepository.save(video);
 
         // 펫 등록을 요청한 유저의 보호소 조회
-        final Shelter shelter = shelterRepository.findByAccount_Email(userDetails.getUsername())
+        final Shelter shelter = shelterRepository.findByAccountEmail(userDetails.getEmail())
             .orElseThrow(() -> new NotFound404("반려동물을 등록하고자 하는 보호소 정보가 존재하지 않습니다."));
 
         // 펫 DB 저장
@@ -61,7 +61,7 @@ public class PetWriteService {
         final Pet updatePet = petRepository.findById(petId)
             .orElseThrow(() -> new NotFound404("등록되지 않은 펫입니다."));
 
-        petValidator.validatePetUpdateAuthority(userDetails.getUsername(), updatePet);
+        petValidator.validatePetUpdateAuthority(userDetails.getEmail(), updatePet);
 
         // 이미지, 비디오 파일 업데이트
         // TODO: 파일 수정 Rollback 처리
@@ -78,7 +78,7 @@ public class PetWriteService {
         final Pet pet = petRepository.findById(petId)
             .orElseThrow(() -> new NotFound404("등록되지 않은 펫입니다."));
 
-        petValidator.validatePetUpdateAuthority(userDetails.getUsername(), pet);
+        petValidator.validatePetUpdateAuthority(userDetails.getEmail(), pet);
 
         // 입양상태를 YES로 변경하고, 보호 만료일을 null로 바꾼다.
         pet.setAdopted(); // TODO: 더 이상 보호소와 관련이 없어서.. 연결된 보호소 정보를 제거할 필요 ?

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
@@ -1,6 +1,7 @@
 package com.daggle.animory.domain.pet.service;
 
 import com.daggle.animory.common.error.exception.NotFound404;
+import com.daggle.animory.common.security.UserDetailsImpl;
 import com.daggle.animory.domain.account.entity.Account;
 import com.daggle.animory.domain.fileserver.S3FileRepository;
 import com.daggle.animory.domain.pet.dto.request.PetRegisterRequestDto;
@@ -29,7 +30,7 @@ public class PetWriteService {
 
     private final PetValidator petValidator;
 
-    public RegisterPetSuccessDto registerPet(final Account account,
+    public RegisterPetSuccessDto registerPet(final UserDetailsImpl userDetails,
                                              final PetRegisterRequestDto petRequestDTO,
                                              final MultipartFile image,
                                              final MultipartFile video) {
@@ -40,7 +41,7 @@ public class PetWriteService {
         final URL videoUrl = fileRepository.save(video);
 
         // 펫 등록을 요청한 유저의 보호소 조회
-        final Shelter shelter = shelterRepository.findByAccountId(account.getId())
+        final Shelter shelter = shelterRepository.findByAccount_Email(userDetails.getUsername())
             .orElseThrow(() -> new NotFound404("반려동물을 등록하고자 하는 보호소 정보가 존재하지 않습니다."));
 
         // 펫 DB 저장
@@ -50,7 +51,7 @@ public class PetWriteService {
         return new RegisterPetSuccessDto(registerPet.getId());
     }
 
-    public UpdatePetSuccessDto updatePet(final Account account,
+    public UpdatePetSuccessDto updatePet(final UserDetailsImpl userDetails,
                                          final int petId,
                                          final PetUpdateRequestDto petUpdateRequestDto,
                                          final MultipartFile image,
@@ -60,7 +61,7 @@ public class PetWriteService {
         final Pet updatePet = petRepository.findById(petId)
             .orElseThrow(() -> new NotFound404("등록되지 않은 펫입니다."));
 
-        petValidator.validatePetUpdateAuthority(account, updatePet);
+        petValidator.validatePetUpdateAuthority(userDetails.getUsername(), updatePet);
 
         // 이미지, 비디오 파일 업데이트
         // TODO: 파일 수정 Rollback 처리
@@ -72,12 +73,12 @@ public class PetWriteService {
         return new UpdatePetSuccessDto(updatePet.getId());
     }
 
-    public void updatePetAdopted(final Account account,
+    public void updatePetAdopted(final UserDetailsImpl userDetails,
                                  final int petId) {
         final Pet pet = petRepository.findById(petId)
             .orElseThrow(() -> new NotFound404("등록되지 않은 펫입니다."));
 
-        petValidator.validatePetUpdateAuthority(account, pet);
+        petValidator.validatePetUpdateAuthority(userDetails.getUsername(), pet);
 
         // 입양상태를 YES로 변경하고, 보호 만료일을 null로 바꾼다.
         pet.setAdopted(); // TODO: 더 이상 보호소와 관련이 없어서.. 연결된 보호소 정보를 제거할 필요 ?

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterController.java
@@ -1,14 +1,13 @@
 package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.common.Response;
-import com.daggle.animory.common.security.RequireRole;
-import com.daggle.animory.domain.account.entity.Account;
-import com.daggle.animory.domain.account.entity.AccountRole;
+import com.daggle.animory.common.security.UserDetailsImpl;
 import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
 import com.daggle.animory.domain.shelter.dto.response.ShelterUpdateSuccessDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,12 +27,11 @@ public class ShelterController {
         return Response.success(shelterService.getShelterProfile(shelterId, page));
     }
 
-    @RequireRole(AccountRole.SHELTER)
     @PutMapping("/{shelterId}")
-    public Response<ShelterUpdateSuccessDto> updateShelter(final Account account,
+    public Response<ShelterUpdateSuccessDto> updateShelter(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                            @PathVariable @Min(0) final Integer shelterId,
                                                            @RequestBody final ShelterUpdateDto shelterUpdateDto) {
-        return Response.success(shelterService.updateShelterInfo(account, shelterId, shelterUpdateDto));
+        return Response.success(shelterService.updateShelterInfo(userDetails, shelterId, shelterUpdateDto));
     }
 
     /**

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ShelterRepository extends JpaRepository<Shelter, Integer> {
-    Optional<Shelter> findByAccount_Email(String accountEmail);
+    Optional<Shelter> findByAccountEmail(String accountEmail);
 
     @Query("select s " +
         "from Shelter s " +

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ShelterRepository extends JpaRepository<Shelter, Integer> {
-    Optional<Shelter> findByAccountId(Integer accountId);
+    Optional<Shelter> findByAccount_Email(String accountEmail);
 
     @Query("select s " +
         "from Shelter s " +

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
@@ -2,7 +2,7 @@ package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.common.error.exception.Forbidden403;
 import com.daggle.animory.common.error.exception.NotFound404;
-import com.daggle.animory.domain.account.entity.Account;
+import com.daggle.animory.common.security.UserDetailsImpl;
 import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
@@ -39,12 +39,12 @@ public class ShelterService {
     }
 
     @Transactional
-    public ShelterUpdateSuccessDto updateShelterInfo(Account account, Integer shelterId, ShelterUpdateDto shelterUpdateDto) {
+    public ShelterUpdateSuccessDto updateShelterInfo(UserDetailsImpl userDetails, Integer shelterId, ShelterUpdateDto shelterUpdateDto) {
         Shelter shelter = shelterRepository.findById(shelterId).orElseThrow(
                 () -> new NotFound404("해당하는 보호소가 존재하지 않습니다.")
         );
 
-        if (!shelter.getAccount().getId().equals(account.getId())) {
+        if (!shelter.getAccount().getEmail().equals(userDetails.getUsername())) {
             throw new Forbidden403("보호소 정보를 수정할 권한이 없습니다.");
         }
 

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
@@ -44,7 +44,7 @@ public class ShelterService {
                 () -> new NotFound404("해당하는 보호소가 존재하지 않습니다.")
         );
 
-        if (!shelter.getAccount().getEmail().equals(userDetails.getUsername())) {
+        if (!shelter.getAccount().getEmail().equals(userDetails.getEmail())) {
             throw new Forbidden403("보호소 정보를 수정할 권한이 없습니다.");
         }
 

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterRepositoryTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterRepositoryTest.java
@@ -1,5 +1,8 @@
 package com.daggle.animory.domain.shelter;
 
+import com.daggle.animory.domain.account.AccountRepository;
+import com.daggle.animory.domain.account.entity.Account;
+import com.daggle.animory.domain.account.entity.AccountRole;
 import com.daggle.animory.domain.shelter.entity.Province;
 import com.daggle.animory.domain.shelter.entity.Shelter;
 import com.daggle.animory.domain.shelter.entity.ShelterAddress;
@@ -8,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,6 +20,8 @@ class ShelterRepositoryTest {
 
     @Autowired
     private ShelterRepository shelterRepository;
+    @Autowired
+    private AccountRepository accountRepository;
 
     @Test
     void findAllByKakaoLocationIdIn() {
@@ -36,5 +42,35 @@ class ShelterRepositoryTest {
 
         // then
         assertThat(foundShelters).contains(shelter);
+    }
+
+    @Test
+    void findByAccountEmail() {
+        // given
+        final Account account = Account.builder()
+                .email("aa@naver.cc")
+                .password("asd!2weW")
+                .role(AccountRole.SHELTER)
+                .build();
+
+        final Shelter shelter = Shelter.builder()
+                .name("테스트 보호소")
+                .address(
+                        ShelterAddress.builder()
+                                .province(Province.광주)
+                                .kakaoLocationId(123456789)
+                                .build()
+                )
+                .account(account)
+                .build();
+
+        accountRepository.save(account);
+        shelterRepository.save(shelter);
+
+        // when
+        Shelter findShelter = shelterRepository.findByAccountEmail(account.getEmail()).get();
+
+        // then
+        assertThat(account.getEmail()).contains(findShelter.getAccount().getEmail());
     }
 }

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
@@ -1,6 +1,7 @@
 package com.daggle.animory.domain.shelter;
 
 import com.daggle.animory.common.error.exception.Forbidden403;
+import com.daggle.animory.common.security.UserDetailsImpl;
 import com.daggle.animory.domain.account.entity.Account;
 import com.daggle.animory.domain.account.entity.AccountRole;
 import com.daggle.animory.domain.pet.entity.Pet;
@@ -104,7 +105,7 @@ public class ShelterServiceTest {
             // stub
             Mockito.when(shelterRepository.findById(any())).thenReturn(Optional.of(shelter));
 
-            ShelterUpdateSuccessDto shelterUpdateSuccessDto = shelterService.updateShelterInfo(account, shelter.getId(), shelterUpdateDto);
+            ShelterUpdateSuccessDto shelterUpdateSuccessDto = shelterService.updateShelterInfo(new UserDetailsImpl(account), shelter.getId(), shelterUpdateDto);
 
             assertAll(
                     () -> assertThat(shelterUpdateSuccessDto.getShelterId()).isEqualTo(shelter.getId()),
@@ -141,7 +142,7 @@ public class ShelterServiceTest {
             // stub
             Mockito.when(shelterRepository.findById(any())).thenReturn(Optional.of(shelter));
 
-            assertThatThrownBy(() -> shelterService.updateShelterInfo(otherAccount, shelter.getId(), shelterUpdateDto))
+            assertThatThrownBy(() -> shelterService.updateShelterInfo(new UserDetailsImpl(otherAccount), shelter.getId(), shelterUpdateDto))
                     .isInstanceOf(Forbidden403.class)
                     .hasMessage("보호소 정보를 수정할 권한이 없습니다.");
         }

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
@@ -85,6 +85,7 @@ public class ShelterServiceTest {
         void 성공_보호소_수정() {
             Account account = Account.builder()
                     .id(1)
+                    .email("asd@asd.com")
                     .build();
 
             Shelter shelter = Shelter.builder()
@@ -118,10 +119,12 @@ public class ShelterServiceTest {
         void 실패_보호소_수정_권한없음() {
             Account account = Account.builder()
                     .id(1)
+                    .email("as231d@asd.com")
                     .build();
 
             Account otherAccount = Account.builder()
                     .id(2)
+                    .email("asd@asd.com")
                     .build();
 
             Shelter shelter = Shelter.builder()


### PR DESCRIPTION
## 작업 내용
- 컨트롤러단에서 권한 인증 어노테이션을 제거
- request로 기존 Account를 받지 않고 @AuthenticationPrincipal 사용해 UserDetailsImpl 객체를 받는 것으로 수정
- UserDetailsImpl의 username인 email로 validatePetUpdateAuthority()메서드 실행
- 위 로직 변경에 따른 테스트 코드 변경

## 기타
- AOP 제거 맘이 아파요


Close #165 