### PR TITLE
API 문서 구체화, 불필요한 로그 제거

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/error/GlobalExceptionHandler.java
+++ b/animory/src/main/java/com/daggle/animory/common/error/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import com.daggle.animory.common.error.exception.BadRequest400Exception;
 import com.daggle.animory.common.error.exception.Forbidden403Exception;
 import com.daggle.animory.common.error.exception.NotFound404Exception;
 import com.daggle.animory.common.error.exception.UnAuthorized401Exception;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.http.HttpStatus;
@@ -16,6 +18,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestValueException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
@@ -30,7 +33,6 @@ import javax.validation.ConstraintViolationException;
 public class GlobalExceptionHandler {
 
     // BAD REQUEST 400
-
     @ExceptionHandler({
         BadRequest400Exception.class,
         MethodArgumentTypeMismatchException.class,
@@ -94,6 +96,8 @@ public class GlobalExceptionHandler {
 
 
     // INTERNAL SERVER ERROR 500
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ApiResponse(responseCode = "500", description = "예상하지 못한 서버 오류", content = @Content)
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Response<Void>> internalServerError(final Exception e){
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Response.error(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR));

--- a/animory/src/main/java/com/daggle/animory/common/logger/MethodExecutionTimeLogger.java
+++ b/animory/src/main/java/com/daggle/animory/common/logger/MethodExecutionTimeLogger.java
@@ -12,9 +12,15 @@ import org.springframework.stereotype.Component;
 public class MethodExecutionTimeLogger {
 
     /**
-     * 모든 method의 실행시간을 로깅합니다.
+     * method의 실행시간을 로깅합니다.
+     *
+     * 다음 클래스와 패키지를 제외합니다.
+     * - com.daggle.animory.common.logger.RequestLogger
+     * - com.daggle.animory.common.error
      */
-    @Around("execution(* com.daggle.animory..*(..))")
+    @Around("execution(* com.daggle.animory..*(..)) && " +
+        "!execution(* com.daggle.animory.common.logger.RequestLogger.*(..)) && " +
+        "!execution(* com.daggle.animory.common.error.*.*(..))")
     public Object logExecutionTime(final ProceedingJoinPoint joinPoint) throws Throwable {
         if(!log.isInfoEnabled()) return joinPoint.proceed(); // Logger Level 적용
 

--- a/animory/src/main/java/com/daggle/animory/common/security/UserDetailsImpl.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/UserDetailsImpl.java
@@ -1,6 +1,7 @@
 package com.daggle.animory.common.security;
 
 import com.daggle.animory.domain.account.entity.Account;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -11,6 +12,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
+@Hidden // Swagger UI에서 노출하지 않음.
 public class UserDetailsImpl implements UserDetails {
     private final Account account;
 

--- a/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountController.java
@@ -30,7 +30,6 @@ public class AccountController implements AccountControllerApi {
     /**
      * 보호소 계정으로 회원가입 API
      */
-    @Override
     @PostMapping("/shelter")
     public Response<Void> signUp(@Valid @RequestBody final ShelterSignUpDto shelterSignUpDto) {
         accountService.registerShelterAccount(shelterSignUpDto);
@@ -40,7 +39,6 @@ public class AccountController implements AccountControllerApi {
     /**
      * 로그인 API
      */
-    @Override
     @PostMapping("/login")
     public ResponseEntity<Response<AccountLoginSuccessDto>> login(@Valid @RequestBody final AccountLoginDto request) {
         final String accessToken = tokenProvider.create(request.email(), AccountRole.SHELTER);
@@ -57,7 +55,6 @@ public class AccountController implements AccountControllerApi {
     /**
      * 이메일 중복 검증 API
      */
-    @Override
     @PostMapping("/email")
     public Response<Void> validateEmail(@Valid @RequestBody final EmailValidateDto emailValidateDto) {
         accountService.validateEmailDuplication(emailValidateDto);

--- a/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountController.java
@@ -1,7 +1,8 @@
-package com.daggle.animory.domain.account;
+package com.daggle.animory.domain.account.controller;
 
 import com.daggle.animory.common.Response;
 import com.daggle.animory.common.security.TokenProvider;
+import com.daggle.animory.domain.account.AccountService;
 import com.daggle.animory.domain.account.dto.request.AccountLoginDto;
 import com.daggle.animory.domain.account.dto.request.EmailValidateDto;
 import com.daggle.animory.domain.account.dto.request.ShelterSignUpDto;
@@ -22,13 +23,14 @@ import javax.validation.Valid;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/account")
-public class AccountController {
+public class AccountController implements AccountControllerApi {
     private final AccountService accountService;
     private final TokenProvider tokenProvider;
 
     /**
      * 보호소 계정으로 회원가입 API
      */
+    @Override
     @PostMapping("/shelter")
     public Response<Void> signUp(@Valid @RequestBody final ShelterSignUpDto shelterSignUpDto) {
         accountService.registerShelterAccount(shelterSignUpDto);
@@ -38,6 +40,7 @@ public class AccountController {
     /**
      * 로그인 API
      */
+    @Override
     @PostMapping("/login")
     public ResponseEntity<Response<AccountLoginSuccessDto>> login(@Valid @RequestBody final AccountLoginDto request) {
         final String accessToken = tokenProvider.create(request.email(), AccountRole.SHELTER);
@@ -54,6 +57,7 @@ public class AccountController {
     /**
      * 이메일 중복 검증 API
      */
+    @Override
     @PostMapping("/email")
     public Response<Void> validateEmail(@Valid @RequestBody final EmailValidateDto emailValidateDto) {
         accountService.validateEmailDuplication(emailValidateDto);

--- a/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountControllerApi.java
@@ -1,0 +1,47 @@
+package com.daggle.animory.domain.account.controller;
+
+import com.daggle.animory.common.Response;
+import com.daggle.animory.domain.account.dto.request.AccountLoginDto;
+import com.daggle.animory.domain.account.dto.request.EmailValidateDto;
+import com.daggle.animory.domain.account.dto.request.ShelterSignUpDto;
+import com.daggle.animory.domain.account.dto.response.AccountLoginSuccessDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import javax.validation.Valid;
+
+@Tag(name = "계정 API", description = "계정 관련 API 입니다.")
+public interface AccountControllerApi {
+
+    @Operation(summary = "보호소 계정으로 회원가입 API", description = "보호소 계정으로 회원가입합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+        @ApiResponse(responseCode = "400", description = """
+            - Email 중복
+            - 비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호여야 합니다.            
+        """, content = @Content),
+    })
+    Response<Void> signUp(@Valid @RequestBody ShelterSignUpDto shelterSignUpDto);
+
+    @Operation(summary = "로그인 API", description = "ID와 비밀번호를 입력받고 인증에 사용할 토큰을 반환합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "로그인 성공"),
+        @ApiResponse(responseCode = "400", description = """
+            - ID 또는 Password 불일치로 인한 로그인 실패
+            - Email 형식 오류, 비밀번호가 null
+        """, content = @Content),
+    })
+    ResponseEntity<Response<AccountLoginSuccessDto>> login(@Valid @RequestBody AccountLoginDto request);
+
+    @Operation(summary = "이메일 중복 검증 API", description = "회원가입에 사용할 이메일이 중복되는지 검사합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "이메일 중복 검증 성공"),
+        @ApiResponse(responseCode = "400", description = "이미 존재하는 이메일인 경우"),
+    })
+    Response<Void> validateEmail(@Valid @RequestBody EmailValidateDto emailValidateDto);
+}

--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,7 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "Pet", description = "Pet 등록, 수정 및 조회 관련 API")
 public interface PetControllerApi {
 
-    @Operation(summary = "Pet 등록 요청",
+    @Operation(summary = "[로그인 필요: 보호소] Pet 등록 요청",
         description = "Pet 등록 요청 API 입니다. 보호소 계정 권한이 필요합니다.")
     Response<RegisterPetSuccessDto> registerPet(
          UserDetailsImpl userDetails,
@@ -32,7 +33,7 @@ public interface PetControllerApi {
                                                     @PathVariable int petId);
 
     // Pet 수정 요청
-    @Operation(summary = "Pet 수정 요청",
+    @Operation(summary = "[로그인 필요: 보호소] Pet 수정 요청",
         description = "보호소 계정 권한이 필요합니다.")
     Response<UpdatePetSuccessDto> updatePet(
             UserDetailsImpl userDetails,
@@ -59,4 +60,10 @@ public interface PetControllerApi {
     @Operation(summary = "Pet 상세 조회",
         description = "")
     Response<PetDto> getPetDetail(@PathVariable int petId);
+
+
+    @Operation(summary = "[로그인 필요: 보호소] Pet 입양 완료 처리",
+        description = "입양 상태가 변경되고, 보호만료날짜가 삭제됩니다.")
+    Response<Void> updatePetAdopted(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                    @PathVariable int petId);
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterController.java
@@ -1,7 +1,8 @@
-package com.daggle.animory.domain.shelter;
+package com.daggle.animory.domain.shelter.controller;
 
 import com.daggle.animory.common.Response;
 import com.daggle.animory.common.security.UserDetailsImpl;
+import com.daggle.animory.domain.shelter.ShelterService;
 import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
@@ -18,15 +19,17 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/shelter")
-public class ShelterController {
+public class ShelterController implements ShelterControllerApi {
     private final ShelterService shelterService;
 
+    @Override
     @GetMapping("/{shelterId}")
     public Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) final Integer shelterId,
                                                    @RequestParam("page") @Min(0) final int page) {
         return Response.success(shelterService.getShelterProfile(shelterId, page));
     }
 
+    @Override
     @PutMapping("/{shelterId}")
     public Response<ShelterUpdateSuccessDto> updateShelter(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                            @PathVariable @Min(0) final Integer shelterId,
@@ -38,6 +41,7 @@ public class ShelterController {
      * 등록된 보호소 필터링 API <br>
      * 리스트 형태의 보호소 정보를 입력받아서, DB에서 kakaoLocationId가 일치하는 Shelter목록을 반환한다.
      */
+    @Override
     @PostMapping("/filter")
     public Response<List<ShelterLocationDto>> filterExistShelterListByLocationId(@RequestBody final List<Integer> shelterLocationIdList) {
         return Response.success(shelterService.filterExistShelterListByLocationId(shelterLocationIdList));

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterController.java
@@ -22,14 +22,12 @@ import java.util.List;
 public class ShelterController implements ShelterControllerApi {
     private final ShelterService shelterService;
 
-    @Override
     @GetMapping("/{shelterId}")
     public Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) final Integer shelterId,
                                                    @RequestParam("page") @Min(0) final int page) {
         return Response.success(shelterService.getShelterProfile(shelterId, page));
     }
 
-    @Override
     @PutMapping("/{shelterId}")
     public Response<ShelterUpdateSuccessDto> updateShelter(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                            @PathVariable @Min(0) final Integer shelterId,
@@ -41,7 +39,6 @@ public class ShelterController implements ShelterControllerApi {
      * 등록된 보호소 필터링 API <br>
      * 리스트 형태의 보호소 정보를 입력받아서, DB에서 kakaoLocationId가 일치하는 Shelter목록을 반환한다.
      */
-    @Override
     @PostMapping("/filter")
     public Response<List<ShelterLocationDto>> filterExistShelterListByLocationId(@RequestBody final List<Integer> shelterLocationIdList) {
         return Response.success(shelterService.filterExistShelterListByLocationId(shelterLocationIdList));

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
@@ -1,0 +1,34 @@
+package com.daggle.animory.domain.shelter.controller;
+
+import com.daggle.animory.common.Response;
+import com.daggle.animory.common.security.UserDetailsImpl;
+import com.daggle.animory.domain.shelter.dto.request.ShelterUpdateDto;
+import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
+import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
+import com.daggle.animory.domain.shelter.dto.response.ShelterUpdateSuccessDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.constraints.Min;
+import java.util.List;
+
+@Tag(name = "보호소 API", description = "보호소 관련 API 입니다.")
+public interface ShelterControllerApi {
+
+    @Operation(summary = "보호소 프로필 조회", description = "보호소 프로필을 조회합니다.")
+    @GetMapping("/{shelterId}")
+    Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) Integer shelterId,
+                                            @RequestParam("page") @Min(0) int page);
+
+    @Operation(summary = "보호소 정보 수정", description = "보호소 정보를 수정합니다.")
+    @PutMapping("/{shelterId}")
+    Response<ShelterUpdateSuccessDto> updateShelter(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                    @PathVariable @Min(0) Integer shelterId,
+                                                    @RequestBody ShelterUpdateDto shelterUpdateDto);
+
+    @Operation(summary = "등록된 보호소 필터링", description = "보호소 ID 배열을 입력받아서, DB에서 kakaoLocationId가 일치하는 보호소 정보를 목록으로 반환합니다.")
+    @PostMapping("/filter")
+    Response<List<ShelterLocationDto>> filterExistShelterListByLocationId(@RequestBody List<Integer> shelterLocationIdList);
+}

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
@@ -22,7 +22,7 @@ public interface ShelterControllerApi {
     Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) Integer shelterId,
                                             @RequestParam("page") @Min(0) int page);
 
-    @Operation(summary = "보호소 정보 수정", description = "보호소 정보를 수정합니다.")
+    @Operation(summary = "[로그인 필요: 보호소] 보호소 정보 수정", description = "보호소 정보를 수정합니다.")
     @PutMapping("/{shelterId}")
     Response<ShelterUpdateSuccessDto> updateShelter(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                     @PathVariable @Min(0) Integer shelterId,

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
@@ -22,11 +22,7 @@ public interface ShortFormControllerApi {
     Response<CategoryShortFormPage> getShortForms(@ModelAttribute @Valid ShortFormSearchCondition searchCondition);
 
 
-    @Operation(summary = "홈 화면 숏폼 비디오 조회", description = """
-    <pre>
-    홈 화면에서 보여 줄 숏폼 비디오들을 조회합니다.    
-    </pre>
-    """)
+    @Operation(summary = "홈 화면 숏폼 비디오 조회", description = "홈 화면에서 보여 줄 숏폼 비디오들을 조회합니다.")
     @GetMapping("/short-forms/home")
     Response<HomeShortFormPage> getHomeShortForms(@RequestParam("page") @Min(0) int page);
 

--- a/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.domain.account;
 
+import com.daggle.animory.domain.account.controller.AccountController;
 import com.daggle.animory.domain.account.dto.request.AccountLoginDto;
 import com.daggle.animory.domain.account.dto.request.EmailValidateDto;
 import com.daggle.animory.domain.account.dto.request.ShelterAddressSignUpDto;

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterControllerTest.java
@@ -1,6 +1,7 @@
 package com.daggle.animory.domain.shelter;
 
 import autoparams.AutoSource;
+import com.daggle.animory.domain.shelter.controller.ShelterController;
 import com.daggle.animory.testutil.webmvctest.BaseWebMvcTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 작업 내용
- API 문서 내용을 추가하였습니다.(API 제목, 설명 등)
  - 인증이 필요한 API의 summary에 [로그인 필요: 권한] 을 추가했습니다.
  - 예상되는 예외 케이스를 모두 명시해주려고 했으나, 작업량이 많고 그만큼 유용하지 않을 듯 해서.. 하다 말았습니다.
- 메소드 실행시간 측정 로깅에서 RequestLogger(URI, METHOD, Query parameter 로그) 메소드 실행을 제외하고 ExceptionHandler 메소드 실행을 제외시켰습니다.(Exception 로그는 "실행시간 측정"과는 별개라서 뜹니다.)



Close #170 ,
Close #175 
