### PR TITLE
Page 입력 초기값 1로 변경, API 문서 개선

### DIFF
--- a/animory/build.gradle
+++ b/animory/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 
 	// jwt, password encoder
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-	implementation 'org.springframework.security:spring-security-crypto:6.1.4'
 
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/animory/src/main/java/com/daggle/animory/common/RefinedPage.java
+++ b/animory/src/main/java/com/daggle/animory/common/RefinedPage.java
@@ -3,18 +3,15 @@ package com.daggle.animory.common;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 
-import javax.validation.constraints.Min;
-
 @Getter
 public abstract class RefinedPage {
 
-    @Min(0)
     protected int pageNumber;
     protected int size;
     protected int totalPages;
 
     protected RefinedPage(final Page<?> page) {
-        this.pageNumber = page.getNumber();
+        this.pageNumber = page.getNumber() + 1; // UI 에서 1부터 시작하는 페이지에 대응하기 위함.
         this.size = page.getSize();
         this.totalPages = page.getTotalPages();
     }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
@@ -70,13 +70,13 @@ public class PetController implements PetControllerApi {
 
     @GetMapping("/profiles/sos")
     public Response<SosPetProfilesDto> getPetSosProfiles(
-        @PageableDefault(page = 0, size = 8, sort = "protectionExpirationDate", direction = Sort.Direction.ASC) final Pageable pageable) {
+        @PageableDefault(page = 1, size = 8, sort = "protectionExpirationDate", direction = Sort.Direction.ASC) final Pageable pageable) {
         return Response.success(petReadService.getPetSosProfiles(pageable));
     }
 
     @GetMapping("/profiles/new")
     public Response<NewPetProfilesDto> getPetNewProfiles(
-        @PageableDefault(page = 0, size = 8, sort = "createdAt", direction = Direction.DESC) final Pageable pageable) {
+        @PageableDefault(page = 1, size = 8, sort = "createdAt", direction = Direction.DESC) final Pageable pageable) {
         return Response.success(petReadService.getPetNewProfiles(pageable));
     }
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
@@ -6,6 +6,9 @@ import com.daggle.animory.domain.pet.dto.request.PetRegisterRequestDto;
 import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
 import com.daggle.animory.domain.pet.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -15,28 +18,51 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "Pet", description = "Pet 등록, 수정 및 조회 관련 API")
+@Tag(name = "Pet", description = """
+        Pet 등록, 수정 및 조회 관련 API
+        최종수정시각: 2023-10-22 23:56
+    """)
 public interface PetControllerApi {
 
     @Operation(summary = "[로그인 필요: 보호소] Pet 등록 요청",
-        description = "Pet 등록 요청 API 입니다. 보호소 계정 권한이 필요합니다.")
+        description = "Pet 등록 요청 API 입니다. Swagger Test가 작동하지 않을 수 있습니다.(https://github.com/springdoc/springdoc-openapi/issues/820)",
+        parameters = {
+            @Parameter(
+                in = ParameterIn.HEADER,
+                name = "Authorization",
+                description = "Bearer Token",
+                required = true,
+                schema = @Schema(type = "string", example = "Bearer Token")
+            )
+        }
+    )
     Response<RegisterPetSuccessDto> registerPet(
-         UserDetailsImpl userDetails,
+        UserDetailsImpl userDetails,
         @RequestPart(value = "petInfo") PetRegisterRequestDto petRegisterRequestDto,
         @RequestPart(value = "profileImage") MultipartFile image,
         @RequestPart(value = "profileVideo") MultipartFile video
     );
 
     @Operation(summary = "Pet 수정 페이지 진입, 기존 펫 정보 확인",
-        description = "Pet 수정 페이지에서, 기존 등록된 정보를 확인하기 위해 호출하는 API 입니다. 보호소 계정 권한이 필요합니다.")
+        description = "Pet 수정 페이지에서, 기존 등록된 정보를 확인하기 위해 호출하는 API 입니다.")
     Response<PetRegisterInfoDto> getPetRegisterInfo(UserDetailsImpl userDetails,
                                                     @PathVariable int petId);
 
     // Pet 수정 요청
     @Operation(summary = "[로그인 필요: 보호소] Pet 수정 요청",
-        description = "보호소 계정 권한이 필요합니다.")
+        description = "보호소 계정 권한이 필요합니다. Swagger Test가 작동하지 않을 수 있습니다.(https://github.com/springdoc/springdoc-openapi/issues/820)",
+        parameters = {
+            @Parameter(
+                in = ParameterIn.HEADER,
+                name = "Authorization",
+                description = "Bearer Token",
+                required = true,
+                schema = @Schema(type = "string", example = "Bearer Token")
+            )
+        }
+    )
     Response<UpdatePetSuccessDto> updatePet(
-            UserDetailsImpl userDetails,
+        UserDetailsImpl userDetails,
         @PathVariable int petId,
         @RequestPart(value = "petInfo") PetUpdateRequestDto petUpdateRequestDto,
         @RequestPart(value = "profileImage", required = false) MultipartFile image,
@@ -48,14 +74,50 @@ public interface PetControllerApi {
     Response<PetProfilesDto> getPetProfiles();
 
     @Operation(summary = "Pet SOS 목록 조회",
-        description = "긴급 도움이 필요한 Pet 목록 입니다. page, size의 기본값은 0, 8 입니다.")
+        description = "긴급 도움이 필요한 Pet 목록 입니다.",
+        parameters = {
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "page",
+                description = "페이지 번호",
+                required = true,
+                schema = @Schema(type = "integer", defaultValue = "1")
+            ),
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "size",
+                description = "페이지 크기",
+                allowEmptyValue = true,
+                schema = @Schema(type = "integer", defaultValue = "8")
+            )
+        }
+    )
     Response<SosPetProfilesDto> getPetSosProfiles(
-        @PageableDefault(page = 0, size = 8, sort = "protectionExpirationDate", direction = Sort.Direction.ASC) Pageable pageable);
+        @Parameter(hidden = true)
+        @PageableDefault(page = 1, size = 8, sort = "protectionExpirationDate", direction = Sort.Direction.ASC) Pageable pageable);
 
     @Operation(summary = "Pet New 목록 조회",
-        description = "신규 등록 Pet 목록 입니다. page, size의 기본값은 0, 8 입니다.")
+        description = "신규 등록 Pet 목록 입니다.",
+        parameters = {
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "page",
+                description = "페이지 번호",
+                required = true,
+                schema = @Schema(type = "integer", defaultValue = "1")
+            ),
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "size",
+                description = "페이지 크기",
+                allowEmptyValue = true,
+                schema = @Schema(type = "integer", defaultValue = "8")
+            )
+        }
+    )
     Response<NewPetProfilesDto> getPetNewProfiles(
-        @PageableDefault(page = 0, size = 8, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable);
+        @Parameter(hidden = true)
+        @PageableDefault(page = 1, size = 8, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable);
 
     @Operation(summary = "Pet 상세 조회",
         description = "")
@@ -63,7 +125,17 @@ public interface PetControllerApi {
 
 
     @Operation(summary = "[로그인 필요: 보호소] Pet 입양 완료 처리",
-        description = "입양 상태가 변경되고, 보호만료날짜가 삭제됩니다.")
+        description = "입양 상태가 변경되고, 보호만료날짜가 삭제됩니다.",
+        parameters = {
+            @Parameter(
+                in = ParameterIn.HEADER,
+                name = "Authorization",
+                description = "Bearer Token",
+                required = true,
+                schema = @Schema(type = "string", example = "Bearer Token")
+            )
+        }
+    )
     Response<Void> updatePetAdopted(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                     @PathVariable int petId);
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ShelterService.java
@@ -10,7 +10,7 @@ import com.daggle.animory.domain.shelter.entity.Shelter;
 import com.daggle.animory.domain.shelter.exception.ShelterNotFoundException;
 import com.daggle.animory.domain.shelter.exception.ShelterPermissionDeniedException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,25 +23,27 @@ public class ShelterService {
     private final PetRepository petRepository;
 
     public ShelterProfilePage getShelterProfile(final Integer shelterId,
-                                                final int page) {
+                                                final Pageable pageable) {
         return ShelterProfilePage.of(
-                shelterRepository.findById(shelterId).orElseThrow(
-                        () -> new ShelterNotFoundException()),
-                petRepository.findByShelterId(shelterId, PageRequest.of(page, 10))
+            shelterRepository.findById(shelterId).orElseThrow(
+                ShelterNotFoundException::new),
+            petRepository.findByShelterId(shelterId, pageable)
         );
     }
 
     public List<ShelterLocationDto> filterExistShelterListByLocationId(final List<Integer> shelterLocationIdList) {
         return shelterRepository.findAllByKakaoLocationIdIn(shelterLocationIdList)
-                .stream()
-                .map(ShelterLocationDto::of)
-                .toList();
+            .stream()
+            .map(ShelterLocationDto::of)
+            .toList();
     }
 
     @Transactional
-    public ShelterUpdateSuccessDto updateShelterInfo(final UserDetailsImpl userDetails, final Integer shelterId, final ShelterUpdateDto shelterUpdateDto) {
+    public ShelterUpdateSuccessDto updateShelterInfo(final UserDetailsImpl userDetails,
+                                                     final Integer shelterId,
+                                                     final ShelterUpdateDto shelterUpdateDto) {
         final Shelter shelter = shelterRepository.findById(shelterId).orElseThrow(
-                () -> new ShelterNotFoundException()
+            ShelterNotFoundException::new
         );
 
         if (!shelter.getAccount().getEmail().equals(userDetails.getEmail())) {
@@ -51,7 +53,7 @@ public class ShelterService {
         shelter.updateInfo(shelterUpdateDto);
 
         return ShelterUpdateSuccessDto.builder()
-                .shelterId(shelterId)
-                .build();
+            .shelterId(shelterId)
+            .build();
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterController.java
@@ -8,6 +8,8 @@ import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
 import com.daggle.animory.domain.shelter.dto.response.ShelterUpdateSuccessDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -22,14 +24,15 @@ import java.util.List;
 public class ShelterController implements ShelterControllerApi {
     private final ShelterService shelterService;
 
+    @Override
     @GetMapping("/{shelterId}")
     public Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) final Integer shelterId,
-                                                   @RequestParam("page") @Min(0) final int page) {
-        return Response.success(shelterService.getShelterProfile(shelterId, page));
+                                                   @PageableDefault(page = 1, size = 10) final Pageable pageable) {
+        return Response.success(shelterService.getShelterProfile(shelterId, pageable));
     }
 
     @PutMapping("/{shelterId}")
-    public Response<ShelterUpdateSuccessDto> updateShelter(@AuthenticationPrincipal UserDetailsImpl userDetails,
+    public Response<ShelterUpdateSuccessDto> updateShelter(@AuthenticationPrincipal final UserDetailsImpl userDetails,
                                                            @PathVariable @Min(0) final Integer shelterId,
                                                            @RequestBody final ShelterUpdateDto shelterUpdateDto) {
         return Response.success(shelterService.updateShelterInfo(userDetails, shelterId, shelterUpdateDto));

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
@@ -7,28 +7,92 @@ import com.daggle.animory.domain.shelter.dto.response.ShelterLocationDto;
 import com.daggle.animory.domain.shelter.dto.response.ShelterProfilePage;
 import com.daggle.animory.domain.shelter.dto.response.ShelterUpdateSuccessDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.Min;
 import java.util.List;
 
-@Tag(name = "보호소 API", description = "보호소 관련 API 입니다.")
+@Tag(name = "보호소 API", description = """
+    최종수정시각: 2023-10-22 23:44
+""")
 public interface ShelterControllerApi {
 
-    @Operation(summary = "보호소 프로필 조회", description = "보호소 프로필을 조회합니다.")
+    @Operation(summary = "보호소 프로필 조회", description = "보호소 프로필을 조회합니다.",
+        parameters = {
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "page",
+                description = "페이지 번호",
+                required = true,
+                schema = @Schema(type = "integer", defaultValue = "1")
+            ),
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "size",
+                description = "페이지 크기, 기본 값은 10입니다.",
+                allowEmptyValue = true,
+                schema = @Schema(type = "integer")
+            )
+        }
+    )
     @GetMapping("/{shelterId}")
     Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) Integer shelterId,
-                                            @RequestParam("page") @Min(0) int page);
 
-    @Operation(summary = "[로그인 필요: 보호소] 보호소 정보 수정", description = "보호소 정보를 수정합니다.")
+                                            @Parameter(hidden = true)
+                                            @PageableDefault(page = 1, size = 10) Pageable pageable);
+
+    @Operation(summary = "[로그인 필요: 보호소] 보호소 정보 수정", description = "보호소 정보를 수정합니다.",
+        parameters = {
+            @Parameter(
+                in = ParameterIn.HEADER,
+                name = "Authorization",
+                description = "Bearer Token",
+                required = true,
+                schema = @Schema(type = "string")
+            ),
+            @Parameter(
+                in = ParameterIn.PATH,
+                name = "shelterId",
+                description = "보호소 ID",
+                required = true,
+                schema = @Schema(type = "integer", minimum = "0")
+            ),
+        },
+        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "보호소 정보 수정 요청",
+            required = true,
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ShelterUpdateDto.class)
+            )
+        )
+    )
     @PutMapping("/{shelterId}")
     Response<ShelterUpdateSuccessDto> updateShelter(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                     @PathVariable @Min(0) Integer shelterId,
                                                     @RequestBody ShelterUpdateDto shelterUpdateDto);
 
-    @Operation(summary = "등록된 보호소 필터링", description = "보호소 ID 배열을 입력받아서, DB에서 kakaoLocationId가 일치하는 보호소 정보를 목록으로 반환합니다.")
+    @Operation(summary = "등록된 보호소 필터링", description = "검색된 보호소의 KakaoLocationID 배열을 입력받아서, DB에서 KakaoLocationId가 일치하는 보호소 정보를 목록으로 반환합니다.",
+        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "서비스 등록 여부를 확인하고자 하는 보호소들의 KakaoLocation ID 배열",
+            required = true,
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = "[10240321, 20192232, 21293650]"
+                )
+            )
+        )
+    )
     @PostMapping("/filter")
     Response<List<ShelterLocationDto>> filterExistShelterListByLocationId(@RequestBody List<Integer> shelterLocationIdList);
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
@@ -38,9 +38,9 @@ public interface ShelterControllerApi {
             @Parameter(
                 in = ParameterIn.QUERY,
                 name = "size",
-                description = "페이지 크기, 기본 값은 10입니다.",
+                description = "페이지 크기",
                 allowEmptyValue = true,
-                schema = @Schema(type = "integer")
+                schema = @Schema(type = "integer", defaultValue = "10")
             )
         }
     )

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
@@ -5,30 +5,33 @@ import com.daggle.animory.domain.shortform.dto.request.ShortFormSearchCondition;
 import com.daggle.animory.domain.shortform.dto.response.CategoryShortFormPage;
 import com.daggle.animory.domain.shortform.dto.response.HomeShortFormPage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ShortFormService {
 
     private final PetRepository petRepository;
 
-    public CategoryShortFormPage getCategoryShortFormPage(final ShortFormSearchCondition searchCondition) {
+    public CategoryShortFormPage getCategoryShortFormPage(final ShortFormSearchCondition searchCondition,
+                                                          final Pageable pageable) {
         return CategoryShortFormPage.of(
             buildCategoryPageTitle(searchCondition),
             petRepository.findSliceBy(
                 searchCondition.type(),
                 searchCondition.area(),
-                searchCondition.pageable()
+                pageable
             )
         );
     }
 
-    public HomeShortFormPage getHomeShortFormPage(final int page) {
+    public HomeShortFormPage getHomeShortFormPage(final Pageable pageable) {
         // TODO: 홈 화면 숏폼 영상은 어떤 순서, 어떤 기준으로 보여줄 것인가?
         return HomeShortFormPage.of(
-            petRepository.findSliceBy(PageRequest.of(page, 10)) // TODO: 하드코딩된 Page 숫자
+            petRepository.findSliceBy(pageable) // TODO: 하드코딩된 Page 숫자
         );
     }
 

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormController.java
@@ -6,14 +6,14 @@ import com.daggle.animory.domain.shortform.dto.request.ShortFormSearchCondition;
 import com.daggle.animory.domain.shortform.dto.response.CategoryShortFormPage;
 import com.daggle.animory.domain.shortform.dto.response.HomeShortFormPage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
-import javax.validation.constraints.Min;
 
 @Validated
 @RestController
@@ -25,17 +25,19 @@ public class ShortFormController implements ShortFormControllerApi {
     /**
      * 다양한 검색 조건 변화에 대응할 수 있는 목적으로 사용할 숏폼 영상 조회 API 입니다.
      */
+    @Override
     @GetMapping("/short-forms")
-    public Response<CategoryShortFormPage> getShortForms(@ModelAttribute @Valid final ShortFormSearchCondition searchCondition) {
-        return Response.success( shortFormService.getCategoryShortFormPage(searchCondition) );
+    public Response<CategoryShortFormPage> getShortForms(@ModelAttribute @Valid final ShortFormSearchCondition searchCondition,
+                                                         @PageableDefault(page = 1, size = 10) final Pageable pageable) {
+        return Response.success(shortFormService.getCategoryShortFormPage(searchCondition, pageable));
     }
 
     /**
      * 홈 화면에서 보여 줄 숏폼 영상들을 조회합니다.
      */
     @GetMapping("/short-forms/home")
-    public Response<HomeShortFormPage> getHomeShortForms(@RequestParam("page") @Min(0) final int page) {
-        return Response.success( shortFormService.getHomeShortFormPage(page) );
+    public Response<HomeShortFormPage> getHomeShortForms(@PageableDefault(page = 1, size = 10) final Pageable pageable) {
+        return Response.success(shortFormService.getHomeShortFormPage(pageable));
     }
 
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
@@ -1,29 +1,90 @@
 package com.daggle.animory.domain.shortform.controller;
 
 import com.daggle.animory.common.Response;
+import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.shelter.entity.Province;
 import com.daggle.animory.domain.shortform.dto.request.ShortFormSearchCondition;
 import com.daggle.animory.domain.shortform.dto.response.CategoryShortFormPage;
 import com.daggle.animory.domain.shortform.dto.response.HomeShortFormPage;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.validation.Valid;
-import javax.validation.constraints.Min;
 
-@Tag(name = "숏폼 비디오 API", description = "숏폼 비디오 관련 API 입니다.")
+@Tag(
+    name = "숏폼 비디오 API",
+    description = """
+        최종수정시각: 2023-10-22 23:24
+    """
+)
 public interface ShortFormControllerApi {
 
     @Operation(summary = "조건부 숏폼 비디오 탐색",
-        description = "다양한 검색 조건 변화에 대응할 수 있는 목적으로 사용할 숏폼 비디오 조회 API 입니다.")
+        description = "다양한 검색 조건 변화에 대응할 수 있는 목적으로 사용할 숏폼 비디오 조회 API 입니다.",
+        parameters = {
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "type",
+                description = "Pet 종류",
+                required = true,
+                schema = @Schema(implementation = PetType.class)
+            ),
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "area",
+                description = "지역",
+                required = true,
+                schema = @Schema(implementation = Province.class)
+            ),
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "page",
+                description = "페이지 번호",
+                required = true,
+                schema = @Schema(type = "integer", defaultValue = "1")
+            ),
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "size",
+                description = "페이지 크기, 기본 값은 10입니다.",
+                allowEmptyValue = true,
+                schema = @Schema(type = "integer")
+            )
+        }
+    )
     @GetMapping("/short-forms")
-    Response<CategoryShortFormPage> getShortForms(@ModelAttribute @Valid ShortFormSearchCondition searchCondition);
+    Response<CategoryShortFormPage> getShortForms(@Parameter(hidden = true)
+                                                  @ModelAttribute @Valid ShortFormSearchCondition searchCondition,
+                                                  @Parameter(hidden = true) // 문서에 깔끔하게 나오지 않을 경우, 이런 식으로 그냥 숨겨버립니다.
+                                                  @PageableDefault(page = 1, size = 10) Pageable pageable);
 
-
-    @Operation(summary = "홈 화면 숏폼 비디오 조회", description = "홈 화면에서 보여 줄 숏폼 비디오들을 조회합니다.")
+    @Operation(summary = "홈 화면 숏폼 비디오 조회",
+        description = "홈 화면에서 보여 줄 숏폼 비디오들을 조회합니다.",
+        parameters = {
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "page",
+                description = "페이지 번호",
+                required = true,
+                schema = @Schema(type = "integer", defaultValue = "1")
+            ),
+            @Parameter(
+                in = ParameterIn.QUERY,
+                name = "size",
+                description = "페이지 크기, 기본 값은 10입니다.",
+                allowEmptyValue = true,
+                schema = @Schema(type = "integer")
+            )
+        }
+    )
     @GetMapping("/short-forms/home")
-    Response<HomeShortFormPage> getHomeShortForms(@RequestParam("page") @Min(0) int page);
+    Response<HomeShortFormPage> getHomeShortForms(@PageableDefault(page = 1, size = 10) Pageable pageable);
 
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
@@ -53,9 +53,9 @@ public interface ShortFormControllerApi {
             @Parameter(
                 in = ParameterIn.QUERY,
                 name = "size",
-                description = "페이지 크기, 기본 값은 10입니다.",
+                description = "페이지 크기",
                 allowEmptyValue = true,
-                schema = @Schema(type = "integer")
+                schema = @Schema(type = "integer", defaultValue = "10")
             )
         }
     )
@@ -78,9 +78,9 @@ public interface ShortFormControllerApi {
             @Parameter(
                 in = ParameterIn.QUERY,
                 name = "size",
-                description = "페이지 크기, 기본 값은 10입니다.",
+                description = "페이지 크기",
                 allowEmptyValue = true,
-                schema = @Schema(type = "integer")
+                schema = @Schema(type = "integer", defaultValue = "10")
             )
         }
     )

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/dto/request/ShortFormSearchCondition.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/dto/request/ShortFormSearchCondition.java
@@ -1,22 +1,11 @@
 package com.daggle.animory.domain.shortform.dto.request;
 
 
-import com.daggle.animory.domain.shelter.entity.Province;
 import com.daggle.animory.domain.pet.entity.PetType;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-
-import javax.validation.constraints.Min;
+import com.daggle.animory.domain.shelter.entity.Province;
 
 public record ShortFormSearchCondition(
     PetType type,
-    Province area,
-
-    @Min(0)
-    int page) { // pageNumber
-
-
-    public Pageable pageable() {
-        return PageRequest.of(page, 10); // TODO: default page size 하드코딩되어 있음.
-    }
+    Province area
+) {
 }

--- a/animory/src/main/resources/application.yml
+++ b/animory/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
     properties:
       hibernate.format_sql: true
   flyway.enabled: false # H2 Error
+  data.web.pageable.one-indexed-parameters: true # Request로 들어오는 Pageable 의 인덱스를 1부터 시작하도록 설정합니다.
 
   # File Upload
   servlet.multipart:

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterControllerTest.java
@@ -37,17 +37,17 @@ public class ShelterControllerTest extends BaseWebMvcTest {
         }
 
         @Test
-        void 실패_보호소값은_음수이면안된다() throws Exception {
-            mvc.perform(get("/shelter/{shelterId}", "-1")
-                            .param("page", "0"))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false));
+        void 성공_페이지입력값이_음수면_자동으로_최소페이지로_취급한다_PAGEABLE_DEFAULT() throws Exception {
+            mvc.perform(get("/shelter/{shelterId}", "1")
+                            .param("page", "-1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
         }
 
         @Test
-        void 실패_페이지입력값은_음수이면안된다() throws Exception {
-            mvc.perform(get("/shelter/{shelterId}", "1")
-                            .param("page", "-1"))
+        void 실패_보호소값은_음수이면안된다() throws Exception {
+            mvc.perform(get("/shelter/{shelterId}", "-1")
+                            .param("page", "0"))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.success").value(false));
         }

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.Optional;
 
@@ -53,7 +54,7 @@ public class ShelterServiceTest {
             Mockito.when(shelterRepository.findById(any())).thenReturn(Optional.of(shelter));
             Mockito.when(petRepository.findByShelterId(any(), any())).thenReturn(pets);
 
-            ShelterProfilePage shelterProfilePage = shelterService.getShelterProfile(shelter.getId(), 0);
+            ShelterProfilePage shelterProfilePage = shelterService.getShelterProfile(shelter.getId(), PageRequest.of(1, 10));
 
             assertThat(shelterProfilePage.shelter().id()).isEqualTo(shelter.getId());
             assertThat(shelterProfilePage.petList().getSize()).isEqualTo(5);
@@ -69,7 +70,7 @@ public class ShelterServiceTest {
             Mockito.when(shelterRepository.findById(any())).thenReturn(Optional.of(shelter));
             Mockito.when(petRepository.findByShelterId(any(), any())).thenReturn(null);
 
-            ShelterProfilePage shelterProfilePage = shelterService.getShelterProfile(shelter.getId(), 0);
+            ShelterProfilePage shelterProfilePage = shelterService.getShelterProfile(shelter.getId(), PageRequest.of(1, 10));
 
             assertThat(shelterProfilePage.shelter().id()).isEqualTo(shelter.getId());
             assertThat(shelterProfilePage.petList().getPets()).isEmpty();

--- a/animory/src/test/java/com/daggle/animory/domain/shortform/ShortFormControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shortform/ShortFormControllerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.web.servlet.ResultActions;
 
 import javax.validation.constraints.Max;
 
@@ -44,14 +43,13 @@ class ShortFormControllerTest extends BaseWebMvcTest {
         }
 
         @Test
-        void 실패_페이지입력값은_음수이면안된다() throws Exception {
+        void 성공_페이지입력값이_음수면_자동으로_최소페이지로_취급한다_PAGEABLE_DEFAULT() throws Exception {
             mvc.perform(get("/short-forms")
                     .param("type", String.valueOf(PetType.DOG))
                     .param("area", String.valueOf(Province.경기))
                     .param("page", "-1"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false))
-                .andDo(print());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
         }
     }
 
@@ -69,12 +67,11 @@ class ShortFormControllerTest extends BaseWebMvcTest {
         }
 
         @Test
-        void 실패_페이지입력값은_음수이면안된다() throws Exception {
+        void 성공_페이지입력값이_음수면_자동으로_최소페이지로_취급한다_PAGEABLE_DEFAULT() throws Exception {
             mvc.perform(get("/short-forms/home")
                     .param("page", "-1"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.success").value(false));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
         }
-
     }
 }


### PR DESCRIPTION
## 작업 내용
- API 문서의 입력 양식을 좀 더 깔끔하게 변경했습니다.
  (한계는, Sprindoc 그리고 Swagger에서 현재 multipart/form-data 내에서 application/json 형식의 데이터를 같이 보내는 형식을 지원하지 않는 것 같습니다.(https://github.com/springdoc/springdoc-openapi/issues/820)
- Page입력값 관련부분은 코멘트에 상세 작업내용 추가하겠습니다.




Close #183 