### PR TITLE
로그인 API, Shelter Profile Dto 변경

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
@@ -1,7 +1,7 @@
 package com.daggle.animory.common.security;
 
-import com.daggle.animory.common.security.exception.InvalidTokenException;
 import com.daggle.animory.common.security.exception.InvalidTokenFormatException;
+import com.daggle.animory.domain.account.dto.TokenWithExpirationDateTimeDto;
 import com.daggle.animory.domain.account.entity.AccountRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -37,6 +37,16 @@ public class TokenProvider {
                 .setExpiration(calcExpirationDateTime()) // 토큰 만료 시간
                 .signWith(SignatureAlgorithm.HS256, key)  // 암호화 알고리즘 및 secretKey
                 .compact();
+    }
+
+    public TokenWithExpirationDateTimeDto createTokenWithExpirationDateTimeDto(final String email, final AccountRole role) {
+        final Date expirationDateTime = calcExpirationDateTime();
+        final String token = TOKEN_PREFIX + Jwts.builder().setSubject(email)
+            .claim(ROLES_CLAIM, role).setIssuedAt(new Date())
+            .setExpiration(expirationDateTime)
+            .signWith(SignatureAlgorithm.HS256, key)
+            .compact(); // 우발적 중복
+        return new TokenWithExpirationDateTimeDto(token, expirationDateTime);
     }
 
 

--- a/animory/src/main/java/com/daggle/animory/domain/account/AccountService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/AccountService.java
@@ -1,7 +1,9 @@
 package com.daggle.animory.domain.account;
 
-import com.daggle.animory.domain.account.dto.request.EmailValidateDto;
+import com.daggle.animory.common.Response;
+import com.daggle.animory.common.security.TokenProvider;
 import com.daggle.animory.domain.account.dto.request.AccountLoginDto;
+import com.daggle.animory.domain.account.dto.request.EmailValidateDto;
 import com.daggle.animory.domain.account.dto.request.ShelterSignUpDto;
 import com.daggle.animory.domain.account.dto.response.AccountLoginSuccessDto;
 import com.daggle.animory.domain.account.entity.Account;
@@ -10,6 +12,8 @@ import com.daggle.animory.domain.account.exception.AlreadyExistEmailException;
 import com.daggle.animory.domain.account.exception.CheckEmailOrPasswordException;
 import com.daggle.animory.domain.shelter.ShelterRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,31 +25,39 @@ public class AccountService {
     private final ShelterRepository shelterRepository;
     private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
 
     @Transactional
     public void registerShelterAccount(final ShelterSignUpDto shelterSignUpDto) {
         validateEmailDuplication(new EmailValidateDto(shelterSignUpDto.email()));
 
         final Account newAccount = accountRepository.save(
-                shelterSignUpDto.getAccount(passwordEncoder));
+            shelterSignUpDto.getAccount(passwordEncoder));
 
         // TODO: 이미 존재하는 쉘터일 경우 예외처리 필요
 
         shelterRepository.save(shelterSignUpDto.getShelter(newAccount));
     }
 
-    public AccountLoginSuccessDto loginShelterAccount(final AccountLoginDto accountLoginDto) {
+    public ResponseEntity<Response<AccountLoginSuccessDto>> loginShelterAccount(final AccountLoginDto accountLoginDto) {
         final Account account = accountRepository.findByEmail(accountLoginDto.email())
-                .orElseThrow(() -> new CheckEmailOrPasswordException());
+            .orElseThrow(CheckEmailOrPasswordException::new);
 
-        if (!passwordEncoder.matches(accountLoginDto.password(), account.getPassword())) {
-            throw new CheckEmailOrPasswordException();
-        }
+        if (!validatePassword(accountLoginDto, account)) throw new CheckEmailOrPasswordException();
 
-        return AccountLoginSuccessDto.builder()
-                .id(account.getId())
-                .accountRole(AccountRole.SHELTER)
-                .build();
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.AUTHORIZATION, tokenProvider.create(account.getEmail(), AccountRole.SHELTER))
+            .body(Response.success(
+                AccountLoginSuccessDto.builder()
+                    .id(account.getId())
+                    .accountRole(AccountRole.SHELTER)
+                    .build()
+            ));
+    }
+
+    private boolean validatePassword(final AccountLoginDto accountLoginDto, final Account account) {
+        return passwordEncoder.matches(accountLoginDto.password(), account.getPassword());
     }
 
     public void validateEmailDuplication(final EmailValidateDto emailValidateDto) {

--- a/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountController.java
@@ -37,9 +37,7 @@ public class AccountController implements AccountControllerApi {
      */
     @PostMapping("/login")
     public ResponseEntity<Response<AccountLoginSuccessDto>> login(@Valid @RequestBody final AccountLoginDto request) {
-
-
-        return accountService.loginShelterAccount(request);
+        return accountService.login(request);
     }
 
     /**

--- a/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountController.java
@@ -1,16 +1,13 @@
 package com.daggle.animory.domain.account.controller;
 
 import com.daggle.animory.common.Response;
-import com.daggle.animory.common.security.TokenProvider;
 import com.daggle.animory.domain.account.AccountService;
 import com.daggle.animory.domain.account.dto.request.AccountLoginDto;
 import com.daggle.animory.domain.account.dto.request.EmailValidateDto;
 import com.daggle.animory.domain.account.dto.request.ShelterSignUpDto;
 import com.daggle.animory.domain.account.dto.response.AccountLoginSuccessDto;
-import com.daggle.animory.domain.account.entity.AccountRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +22,6 @@ import javax.validation.Valid;
 @RequestMapping("/account")
 public class AccountController implements AccountControllerApi {
     private final AccountService accountService;
-    private final TokenProvider tokenProvider;
 
     /**
      * 보호소 계정으로 회원가입 API
@@ -41,15 +37,9 @@ public class AccountController implements AccountControllerApi {
      */
     @PostMapping("/login")
     public ResponseEntity<Response<AccountLoginSuccessDto>> login(@Valid @RequestBody final AccountLoginDto request) {
-        final String accessToken = tokenProvider.create(request.email(), AccountRole.SHELTER);
 
-        log.debug("accessToken : " + accessToken);
 
-        return ResponseEntity.ok()
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(Response.success(
-                        accountService.loginShelterAccount(request)
-                ));
+        return accountService.loginShelterAccount(request);
     }
 
     /**

--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/TokenWithExpirationDateTimeDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/TokenWithExpirationDateTimeDto.java
@@ -1,0 +1,9 @@
+package com.daggle.animory.domain.account.dto;
+
+public record TokenWithExpirationDateTimeDto(
+    String token,
+    java.util.Date expirationDateTime
+) {
+
+
+}

--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/response/AccountInfo.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/response/AccountInfo.java
@@ -1,0 +1,11 @@
+package com.daggle.animory.domain.account.dto.response;
+
+import com.daggle.animory.domain.account.entity.AccountRole;
+import lombok.Builder;
+
+@Builder
+public record AccountInfo(
+    Integer id,
+    AccountRole role
+) {
+}

--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/response/AccountLoginSuccessDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/response/AccountLoginSuccessDto.java
@@ -3,6 +3,13 @@ package com.daggle.animory.domain.account.dto.response;
 import com.daggle.animory.domain.account.entity.AccountRole;
 import lombok.Builder;
 
+import java.util.Date;
+
 @Builder
-public record AccountLoginSuccessDto(Integer id, AccountRole accountRole) {
+public record AccountLoginSuccessDto(
+    Integer id,
+    AccountRole accountRole,
+
+    Date tokenExpirationDateTime
+) {
 }

--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/response/AccountLoginSuccessDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/response/AccountLoginSuccessDto.java
@@ -1,14 +1,13 @@
 package com.daggle.animory.domain.account.dto.response;
 
-import com.daggle.animory.domain.account.entity.AccountRole;
 import lombok.Builder;
 
 import java.util.Date;
 
 @Builder
 public record AccountLoginSuccessDto(
-    Integer id,
-    AccountRole accountRole,
+    Integer accountId,
+    AccountInfo accountInfo,
 
     Date tokenExpirationDateTime
 ) {

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetValidator.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetValidator.java
@@ -44,7 +44,7 @@ public class PetValidator {
 
         // Data Integrity Validation
         final Shelter shelterFromRequest = shelterRepository.findByAccountEmail(email)
-            .orElseThrow(() -> new ShelterNotFoundException());
+            .orElseThrow(ShelterNotFoundException::new);
         final Shelter shelterToUpdate = pet.getShelter();
 
         // Authorization Validation

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/PetProfileDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/PetProfileDto.java
@@ -2,20 +2,27 @@ package com.daggle.animory.domain.shelter.dto.response;
 
 import com.daggle.animory.domain.pet.entity.AdoptionStatus;
 import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
 import lombok.Builder;
 
 @Builder
 public record PetProfileDto(
-        Integer id,
-        String name,
-        AdoptionStatus adoptionStatus
+    Integer id,
+    String name,
+
+    String age,
+
+    String profileImageUrl,
+    AdoptionStatus adoptionStatus
 ) {
 
     public static PetProfileDto of(final Pet pet) {
         return PetProfileDto.builder()
-                .id(pet.getId())
-                .name(pet.getName())
-                .adoptionStatus(pet.getAdoptionStatus())
-                .build();
+            .id(pet.getId())
+            .name(pet.getName())
+            .age(PetAgeToBirthDateConverter.birthDateToAge(pet.getBirthDate()))
+            .profileImageUrl(pet.getProfileImageUrl())
+            .adoptionStatus(pet.getAdoptionStatus())
+            .build();
     }
 }

--- a/animory/src/test/java/com/daggle/animory/acceptance/AccountTest.java
+++ b/animory/src/test/java/com/daggle/animory/acceptance/AccountTest.java
@@ -76,8 +76,8 @@ class AccountTest extends AcceptanceTest {
 
 
         result = mvc.perform(post("/account/shelter")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(om.writeValueAsString(shelterSignUpDto)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(shelterSignUpDto)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.success").value(false));
     }
@@ -94,11 +94,15 @@ class AccountTest extends AcceptanceTest {
             .content(om.writeValueAsString(accountLoginDto)));
 
         assertSuccess();
+        result.andExpect(jsonPath("$.response.accountId").value(1))
+            .andExpect(jsonPath("$.response.accountInfo.id").value(1))
+            .andExpect(jsonPath("$.response.accountInfo.role").value("SHELTER"))
+            .andExpect(jsonPath("$.response.tokenExpirationDateTime").isNotEmpty());
 
         // header authorization field exists
-        assertThat( result.andReturn()
+        assertThat(result.andReturn()
             .getResponse()
-            .getHeader("Authorization") ).isNotNull();
+            .getHeader("Authorization")).isNotNull();
     }
 
     @Test
@@ -109,8 +113,8 @@ class AccountTest extends AcceptanceTest {
             .build();
 
         result = mvc.perform(post("/account/login")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(om.writeValueAsString(accountLoginDto)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(accountLoginDto)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.error.message").value("이메일 또는 비밀번호를 확인해주세요."));

--- a/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
@@ -15,7 +15,8 @@ import org.springframework.http.MediaType;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Import(AccountController.class)
 public class AccountControllerTest extends BaseWebMvcTest {
@@ -157,12 +158,11 @@ public class AccountControllerTest extends BaseWebMvcTest {
                     .password("asdfA123!")
                     .build();
 
+
             mvc.perform(post("/account/login")
                             .content(om.writeValueAsString(accountLoginDto))
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(header().exists("Authorization"))
                     .andDo(print());
         }
 


### PR DESCRIPTION
## 작업 내용
- 로그인이 특정 AccountRole에 종속적으로 동작하지 않게 변경했습니다.(switch문 참조)
- 로그인 응답 시, "토큰에 들어있는 만료기한을 Body에 중복으로 넣어서 응답" 추가하였습니다.(#184 참조)
- Shelter Profile 조회 Dto에 imageUrl, age 추가하였습니다.

Close #184  ,
Close #185 ,
Close #188 