### PR TITLE
JwtException 발생 시 응답 Body가 두번 나가는 버그 해결

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/security/JwtAuthenticationFilter.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.common.security;
 
+import com.daggle.animory.common.security.exception.InvalidTokenFormatException;
 import com.daggle.animory.domain.account.entity.Account;
 import com.daggle.animory.domain.account.entity.AccountRole;
 import io.jsonwebtoken.*;
@@ -68,6 +69,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
             throw new JwtException("토큰 기한 만료");
         } catch (UnsupportedJwtException e) {
             log.info("Unsupported JWT token.");
+            throw new JwtException("지원하지 않는 JWT 토큰");
         } catch (IllegalArgumentException e) {
             log.info("JWT token compact of handler are invalid.");
             throw new JwtException("JWT token compact of handler are invalid.");

--- a/animory/src/main/java/com/daggle/animory/common/security/SecurityConfig.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/SecurityConfig.java
@@ -18,6 +18,9 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import javax.servlet.http.HttpServletResponse;
+
 @Slf4j
 @Configuration
 @EnableWebSecurity
@@ -56,7 +59,7 @@ public class SecurityConfig {
 
         http.exceptionHandling().authenticationEntryPoint((request, response, authException) -> {
             log.info(authException.getMessage());
-            resolver.resolveException(request, response, null, new UnAuthorizedException());
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         });
 
         http.exceptionHandling().accessDeniedHandler((request, response, accessDeniedException) -> {

--- a/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
@@ -1,7 +1,5 @@
 package com.daggle.animory.common.security;
 
-import com.daggle.animory.common.security.exception.InvalidTokenException;
-import com.daggle.animory.common.security.exception.InvalidTokenFormatException;
 import com.daggle.animory.domain.account.entity.AccountRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -9,7 +7,6 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 import java.util.Base64;
@@ -51,9 +48,6 @@ public class TokenProvider {
 
     // 헤더에서 token 추출
     public Claims resolveToken(final String bearerToken) {
-        if (!StringUtils.hasText(bearerToken) || !bearerToken.startsWith(TOKEN_PREFIX))
-            throw new InvalidTokenFormatException();
-
         final String token = cutTokenPrefix(bearerToken);
         return extractBody(token);
     }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/PetProfilePage.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/PetProfilePage.java
@@ -8,22 +8,22 @@ import org.springframework.data.domain.Page;
 import java.util.ArrayList;
 import java.util.List;
 @Getter
-public class PetProfileSlice extends RefinedPage {
+public class PetProfilePage extends RefinedPage {
     private final List<PetProfileDto> pets;
 
-    private PetProfileSlice(final Page<Pet> page) {
+    private PetProfilePage(final Page<Pet> page) {
         super(page);
         this.pets = page.getContent().stream().map(PetProfileDto::of).toList();
     }
-    private PetProfileSlice() {
+    private PetProfilePage() {
         this.pageNumber = 0;
         this.size = 0;
         this.totalPages = 0;
         this.pets = new ArrayList<>();
     }
 
-    public static PetProfileSlice of(final Page<Pet> petPage) {
-        if (petPage == null) return new PetProfileSlice();
-        return new PetProfileSlice(petPage);
+    public static PetProfilePage of(final Page<Pet> petPage) {
+        if (petPage == null) return new PetProfilePage();
+        return new PetProfilePage(petPage);
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/ShelterProfilePage.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/dto/response/ShelterProfilePage.java
@@ -6,14 +6,14 @@ import org.springframework.data.domain.Page;
 
 public record ShelterProfilePage(
         ShelterInfoDto shelter,
-        PetProfileSlice petList
+        PetProfilePage petList
 ) {
 
     public static ShelterProfilePage of(final Shelter shelter,
                                         final Page<Pet> petPage) {
         return new ShelterProfilePage(
                 ShelterInfoDto.of(shelter),
-                PetProfileSlice.of(petPage)
+                PetProfilePage.of(petPage)
         );
     }
 }

--- a/animory/src/test/java/com/daggle/animory/acceptance/PetTest.java
+++ b/animory/src/test/java/com/daggle/animory/acceptance/PetTest.java
@@ -8,6 +8,7 @@ import com.daggle.animory.domain.pet.entity.PetType;
 import com.daggle.animory.domain.pet.entity.Sex;
 import com.daggle.animory.testutil.AcceptanceTest;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -29,82 +30,82 @@ class PetTest extends AcceptanceTest {
     final MockMultipartFile image = new MockMultipartFile("profileImage", "image.jpg", "image/jpeg", "image".getBytes(StandardCharsets.UTF_8));
     final MockMultipartFile video = new MockMultipartFile("profileVideo", "video.mp4", "video/mp4", "video".getBytes(StandardCharsets.UTF_8));
 
-    @Test
-    void 강아지를_한마리_등록한다() throws Exception {
-        final String TOKEN = getShelterToken();
-
+    @Nested
+    class 강아지_등록 {
         final PetRegisterRequestDto petInfo = PetRegisterRequestDto.builder()
-            .name("뽀삐")
-            .age("0년3개월")
-            .type(PetType.DOG)
-            .weight(3.5f)
-            .size("태어난지 얼마 안되서 작음")
-            .sex(Sex.MALE)
-            .vaccinationStatus("아직 접종 안함")
-            .adoptionStatus(AdoptionStatus.NO)
-            .neutralizationStatus(NeutralizationStatus.NO)
-            .protectionExpirationDate(LocalDate.now().plusMonths(6))
-            .description("뽀삐는 아직 어린 아이라서 많이 놀아줘야해요.")
-            .petPolygonProfileDto(
-                PetPolygonProfileDto.builder()
-                    .activeness(1)
-                    .adaptability(1)
-                    .affinity(3)
-                    .athletic(1)
-                    .intelligence(4)
-                    .build()
-            )
-            .build();
-        final MockPart petInfoRequestPart = new MockPart("petInfo", om.writeValueAsString(petInfo).getBytes(StandardCharsets.UTF_8));
-        petInfoRequestPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+                .name("뽀삐")
+                .age("0년3개월")
+                .type(PetType.DOG)
+                .weight(3.5f)
+                .size("태어난지 얼마 안되서 작음")
+                .sex(Sex.MALE)
+                .vaccinationStatus("아직 접종 안함")
+                .adoptionStatus(AdoptionStatus.NO)
+                .neutralizationStatus(NeutralizationStatus.NO)
+                .protectionExpirationDate(LocalDate.now().plusMonths(6))
+                .description("뽀삐는 아직 어린 아이라서 많이 놀아줘야해요.")
+                .petPolygonProfileDto(
+                        PetPolygonProfileDto.builder()
+                                .activeness(1)
+                                .adaptability(1)
+                                .affinity(3)
+                                .athletic(1)
+                                .intelligence(4)
+                                .build()
+                )
+                .build();
 
+        @Test
+        void 강아지를_한마리_등록한다() throws Exception {
+            final String TOKEN = getShelterToken();
 
+            final MockPart petInfoRequestPart = new MockPart("petInfo", om.writeValueAsString(petInfo).getBytes(StandardCharsets.UTF_8));
+            petInfoRequestPart.getHeaders().setContentType(MediaType.APPLICATION_JSON);
 
-        result = mvc.perform(multipart(POST, "/pet")
-            .file(image)
-            .file(video)
-            .part(petInfoRequestPart)
-            .header("Authorization", TOKEN ));
+            result = mvc.perform(multipart(POST, "/pet")
+                    .file(image)
+                    .file(video)
+                    .part(petInfoRequestPart)
+                    .header("Authorization", TOKEN));
 
-        assertSuccess();
+            assertSuccess();
+        }
+
+        /**
+         * <pre>
+         * 상세정보
+         * 	동물 상세 정보 조회 API에서는
+         * 	1. 보호중인 보호소의 정보를 알 수 있다.
+         * 	2. 오각형으로 이뤄진 동물 특성을 알 수 있다.
+         * 	3. 해당 동물의 프로필 사진 한 개를 볼 수 있다. </pre>
+         */
+        @Test
+        void 펫_상세정보_조회() throws Exception {
+            result = mvc.perform(get("/pet/{petId}", 1))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.response.shelterInfo.id").isNotEmpty())
+                    .andExpect(jsonPath("$.response.shelterInfo.name").isNotEmpty())
+                    .andExpect(jsonPath("$.response.shelterInfo.contact").isNotEmpty())
+                    .andExpect(jsonPath("$.response.petPolygonProfileDto").isNotEmpty())
+                    .andExpect(jsonPath("$.response.petPolygonProfileDto.intelligence").value(3))
+                    .andExpect(jsonPath("$.response.profileImageUrl").isNotEmpty());
+        }
+
+        /**
+         * 유기동물 프로필 리스트
+         * 동물 기본 정보(식별자, 프로필 사진, 이름, 나이, 소속 보호소, 입양상태, 안락사 예정여부)를 확인할 수 있다.
+         * 조회 기준은 둥록일 최신순 또는 보호만료일이 가까운 순으로 확인할 수 있다.
+         * 더보기 버튼을 통해 최신순 또는 안락사 기간 기준으로 각각 전체 리스트를 확인할 수 있다.
+         * 페이지 당 프로필을 각각 8개 단위로 확인할 수 있다.
+         */
+        @Test
+        void 유기동물_프로필_리스트() throws Exception {
+            result = mvc.perform(get("/pet/profiles"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.response.sosList").isNotEmpty())
+                    .andExpect(jsonPath("$.response.newList").isNotEmpty())
+                    // TODO:
+                    .andDo(print());
+        }
     }
-
-
-    /**<pre>
-     * 상세정보
-     * 	동물 상세 정보 조회 API에서는
-     * 	1. 보호중인 보호소의 정보를 알 수 있다.
-     * 	2. 오각형으로 이뤄진 동물 특성을 알 수 있다.
-     * 	3. 해당 동물의 프로필 사진 한 개를 볼 수 있다. </pre>
-     */
-    @Test
-    void 펫_상세정보_조회() throws Exception {
-        result = mvc.perform(get("/pet/{petId}", 1))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.response.shelterInfo.id").isNotEmpty())
-            .andExpect(jsonPath("$.response.shelterInfo.name").isNotEmpty())
-            .andExpect(jsonPath("$.response.shelterInfo.contact").isNotEmpty())
-            .andExpect(jsonPath("$.response.petPolygonProfileDto").isNotEmpty())
-            .andExpect(jsonPath("$.response.petPolygonProfileDto.intelligence").value(3))
-            .andExpect(jsonPath("$.response.profileImageUrl").isNotEmpty());
-    }
-
-    /**
-     * 유기동물 프로필 리스트
-     * 	동물 기본 정보(식별자, 프로필 사진, 이름, 나이, 소속 보호소, 입양상태, 안락사 예정여부)를 확인할 수 있다.
-     * 	조회 기준은 둥록일 최신순 또는 보호만료일이 가까운 순으로 확인할 수 있다.
-     * 	더보기 버튼을 통해 최신순 또는 안락사 기간 기준으로 각각 전체 리스트를 확인할 수 있다.
-     * 	페이지 당 프로필을 각각 8개 단위로 확인할 수 있다.
-     */
-    @Test
-    void 유기동물_프로필_리스트() throws Exception {
-        result = mvc.perform(get("/pet/profiles"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.response.sosList").isNotEmpty())
-            .andExpect(jsonPath("$.response.newList").isNotEmpty())
-            // TODO:
-            .andDo(print());
-    }
-
-
 }


### PR DESCRIPTION
## 이슈 상황
- JwtAuthenticationFilter 에서 JwtException이 터지면 JwtAuthenticationFilter 바로 뒤의 JwtExceptionFilter가 처리하도록 하였으나,
- HandlerExceptionResolver가 채가 authenticationEntryPoint한테 전달하여 처리하는 듯합니다.(이때 JwtException형태가 아닌 InsufficientAuthenticationException로 변경되어 전달됨)
- 그 후에 JwtExceptionFilter가 다시 JwtException를 처리하여 응답 Body가 두 번 작성됩니다.

## 작업 내용
- 위 상황을 해결하기 위해 가능한 모든 시도 해봤으나
- 현 상황에서 최선은 authenticationEntryPoint에서 HandlerExceptionResolver를 제거하고 JwtExceptionFilter에서 처리한 응답을 전달하도록 수정하였습니다.
 
## 기타
- 다른 좋은 방법이 있다면 말해주세요.


Close #186 