### PR TITLE
swagger api에 해당하는 커스텀 예외만 표시 및 예외문서화 상세화

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/exception/handler/GlobalExceptionHandler.java
+++ b/animory/src/main/java/com/daggle/animory/common/exception/handler/GlobalExceptionHandler.java
@@ -3,9 +3,6 @@ package com.daggle.animory.common.exception.handler;
 
 import com.daggle.animory.common.Response;
 import com.daggle.animory.common.security.exception.ForbiddenException;
-import com.daggle.animory.common.security.exception.InvalidTokenException;
-import com.daggle.animory.common.security.exception.InvalidTokenFormatException;
-import com.daggle.animory.common.security.exception.UnAuthorizedException;
 import com.daggle.animory.domain.account.exception.AlreadyExistEmailException;
 import com.daggle.animory.domain.account.exception.CheckEmailOrPasswordException;
 import com.daggle.animory.domain.fileserver.exception.*;
@@ -43,117 +40,80 @@ import javax.validation.ConstraintViolationException;
 public class GlobalExceptionHandler {
 
     // BAD REQUEST 400
-    @ApiResponse(responseCode = "400", description = "이메일 중복 오류", content = @Content)
     @ExceptionHandler({AlreadyExistEmailException.class})
     public ResponseEntity<Response<Void>> handleAlreadyExistEmailException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
-    @ApiResponse(responseCode = "400", description = "로그인 올바르지 못한 이메일 또는 비밀번호 오류", content = @Content)
     @ExceptionHandler({CheckEmailOrPasswordException.class})
     public ResponseEntity<Response<Void>> handleCheckEmailOrPasswordException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
-    @ApiResponse(responseCode = "400", description = "파일 형식 오류", content = @Content)
     @ExceptionHandler({InvalidFileTypeException.class})
     public ResponseEntity<Response<Void>> handleInvalidFileTypeException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
-    @ApiResponse(responseCode = "400", description = "이미지 형식 오류", content = @Content)
     @ExceptionHandler({InvalidImageTypeException.class})
     public ResponseEntity<Response<Void>> handleInvalidImageTypeException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
-    @ApiResponse(responseCode = "400", description = "비디오 형식 오류", content = @Content)
     @ExceptionHandler({InvalidVideoTypeException.class})
     public ResponseEntity<Response<Void>> handleInvalidVideoTypeException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
-    @ApiResponse(responseCode = "400", description = "빈 이미지 파일 오류", content = @Content)
     @ExceptionHandler({NotFoundImageException.class})
     public ResponseEntity<Response<Void>> handleNotFoundImageException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
-    @ApiResponse(responseCode = "400", description = "빈 비디오 파일 오류", content = @Content)
     @ExceptionHandler({NotFoundVideoException.class})
     public ResponseEntity<Response<Void>> handleNotFoundVideoException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
-    @ApiResponse(responseCode = "400", description = "잘못된 나이 형식 오류", content = @Content)
     @ExceptionHandler({InvalidPetAgeFormatException.class})
     public ResponseEntity<Response<Void>> handleInvalidPetAgeTypeException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
-    @ApiResponse(responseCode = "400", description = "년수 범위 오류", content = @Content)
     @ExceptionHandler({InvalidPetYearRangeException.class})
     public ResponseEntity<Response<Void>> handleInvalidPetYearRangeException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
-    @ApiResponse(responseCode = "400", description = "개월 범위 파일 오류", content = @Content)
     @ExceptionHandler({InvalidPetMonthRangeException.class})
     public ResponseEntity<Response<Void>> handleInvalidPetMonthRangeException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
-
-    @ApiResponse(responseCode = "400", description = "보호소 중복 오류", content = @Content)
     @ExceptionHandler({ShelterAlreadyExistException.class})
     public ResponseEntity<Response<Void>> handleShelterAlreadyExistException(final Exception e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
     }
 
-    // 401
-    @ApiResponse(responseCode = "401", description = "시큐리티 인증 오류", content = @Content)
-    @ExceptionHandler({UnAuthorizedException.class})
-    public ResponseEntity<Response<Void>> handleUnAuthorizedException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Response.error(e.getMessage(), HttpStatus.UNAUTHORIZED));
-    }
-
-    @ApiResponse(responseCode = "401", description = "토큰 형식 오류", content = @Content)
-    @ExceptionHandler({InvalidTokenFormatException.class})
-    public ResponseEntity<Response<Void>> handleInvalidTokenFormatException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Response.error(e.getMessage(), HttpStatus.UNAUTHORIZED));
-    }
-
-    @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰 오류", content = @Content)
-    @ExceptionHandler({InvalidTokenException.class})
-    public ResponseEntity<Response<Void>> handleInvalidTokenException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Response.error(e.getMessage(), HttpStatus.UNAUTHORIZED));
-    }
-
     // 403
-    @ApiResponse(responseCode = "403", description = "보호소 수정 권한 오류", content = @Content)
     @ExceptionHandler({ShelterPermissionDeniedException.class})
     public ResponseEntity<Response<Void>> handleShelterPermissionDeniedException(final Exception e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Response.error(e.getMessage(), HttpStatus.FORBIDDEN));
     }
 
-    @ApiResponse(responseCode = "403", description = "시큐리티 권한 오류", content = @Content)
     @ExceptionHandler({ForbiddenException.class})
     public ResponseEntity<Response<Void>> handleForbiddenExceptionn(final Exception e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Response.error(e.getMessage(), HttpStatus.FORBIDDEN));
     }
 
     // 404
-    @ApiResponse(responseCode = "404", description = "존재하지 않는 펫 오류", content = @Content)
     @ExceptionHandler({PetNotFoundException.class})
     public ResponseEntity<Response<Void>> handlePetNotFoundException(final Exception e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Response.error(e.getMessage(), HttpStatus.NOT_FOUND));
     }
-
-    @ApiResponse(responseCode = "404", description = "보호소 중복 오류", content = @Content)
     @ExceptionHandler({ShelterNotFoundException.class})
     public ResponseEntity<Response<Void>> handleShelterNotFoundException(final Exception e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Response.error(e.getMessage(), HttpStatus.NOT_FOUND));
     }
 
-    @ApiResponse(responseCode = "413", description = "File Size, Request Size 제한 초과", content = @Content)
     @ExceptionHandler({MaxUploadSizeExceededException.class})
     public ResponseEntity<Response<Void>> handleMaxUploadSizeExceededException(final RuntimeException e) {
         return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(Response.error(e.getMessage(), HttpStatus.PAYLOAD_TOO_LARGE));
@@ -167,7 +127,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Response.error(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR));
     }
 
-    @ApiResponse(responseCode = "500", description = "S3 저장 오류", content = @Content)
     @ExceptionHandler({AmazonS3SaveError.class})
     public ResponseEntity<Response<Void>> handleAmazonS3SaveException(final Exception e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Response.error(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR));

--- a/animory/src/main/java/com/daggle/animory/common/security/JwtAuthenticationFilter.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.daggle.animory.common.security;
 
-import com.daggle.animory.common.security.exception.InvalidTokenFormatException;
 import com.daggle.animory.domain.account.entity.Account;
 import com.daggle.animory.domain.account.entity.AccountRole;
 import io.jsonwebtoken.*;

--- a/animory/src/main/java/com/daggle/animory/common/security/SecurityConfig.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.daggle.animory.common.security;
 
 import com.daggle.animory.common.security.exception.ForbiddenException;
 import com.daggle.animory.common.security.exception.JwtExceptionFilter;
-import com.daggle.animory.common.security.exception.UnAuthorizedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
@@ -1,6 +1,5 @@
 package com.daggle.animory.common.security;
 
-import com.daggle.animory.common.security.exception.InvalidTokenFormatException;
 import com.daggle.animory.domain.account.dto.TokenWithExpirationDateTimeDto;
 import com.daggle.animory.domain.account.entity.AccountRole;
 import io.jsonwebtoken.Claims;

--- a/animory/src/main/java/com/daggle/animory/common/security/UserDetailsServiceImpl.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/UserDetailsServiceImpl.java
@@ -16,7 +16,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) {
         Account account = accountRepository.findByEmail(username).orElseThrow(
-                () -> new CheckEmailOrPasswordException()
+                CheckEmailOrPasswordException::new
         );
         return new UserDetailsImpl(account);
     }

--- a/animory/src/main/java/com/daggle/animory/common/security/exception/InvalidTokenException.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/exception/InvalidTokenException.java
@@ -1,8 +1,0 @@
-package com.daggle.animory.common.security.exception;
-
-public class InvalidTokenException  extends RuntimeException {
-    @Override
-    public String getMessage() {
-        return SecurityExceptionMessage.INVALID_TOKEN.getMessage();
-    }
-}

--- a/animory/src/main/java/com/daggle/animory/common/security/exception/InvalidTokenFormatException.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/exception/InvalidTokenFormatException.java
@@ -1,8 +1,0 @@
-package com.daggle.animory.common.security.exception;
-
-public class InvalidTokenFormatException extends RuntimeException {
-    @Override
-    public String getMessage() {
-        return SecurityExceptionMessage.INVALID_TOKEN_FORMAT.getMessage();
-    }
-}

--- a/animory/src/main/java/com/daggle/animory/common/security/exception/UnAuthorizedException.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/exception/UnAuthorizedException.java
@@ -1,8 +1,0 @@
-package com.daggle.animory.common.security.exception;
-
-public class UnAuthorizedException extends RuntimeException {
-    @Override
-    public String getMessage() {
-        return SecurityExceptionMessage.UNAUTHORIZED.getMessage();
-    }
-}

--- a/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/controller/AccountControllerApi.java
@@ -35,6 +35,7 @@ public interface AccountControllerApi {
             - ID 또는 Password 불일치로 인한 로그인 실패
             - Email 형식 오류, 비밀번호가 null
         """, content = @Content),
+        @ApiResponse(responseCode = "404", description = "해당하는 보호소를 찾을 수 없는 경우", content = @Content)
     })
     ResponseEntity<Response<AccountLoginSuccessDto>> login(@Valid @RequestBody AccountLoginDto request);
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
@@ -8,7 +8,10 @@ import com.daggle.animory.domain.pet.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -36,6 +39,16 @@ public interface PetControllerApi {
             )
         }
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 이미지 형식이 jpg, jpeg, png, gif, bmp, tiff 중 하나가 아닐 경우" +
+                    "\t\n 2. 비디오 형식이 mp4, avi, mov, wmv, flv, mkv, webm 중 하나가 아닐 경우" +
+                    "\t\n 3. 빈 이미지 파일일 경우" +
+                    "\t\n 4. 빈 비디오 파일일 경우" +
+                    "\t\n 5. 잘못된 나이 형식일 경우", content = @Content),
+            @ApiResponse(responseCode = "404", description = "보호소를 찾을 수 없는 경우", content = @Content),
+            @ApiResponse(responseCode = "500", description = "S3 저장 오류", content = @Content)
+    })
     Response<RegisterPetSuccessDto> registerPet(
         UserDetailsImpl userDetails,
         @RequestPart(value = "petInfo") PetRegisterRequestDto petRegisterRequestDto,
@@ -45,6 +58,9 @@ public interface PetControllerApi {
 
     @Operation(summary = "Pet 수정 페이지 진입, 기존 펫 정보 확인",
         description = "Pet 수정 페이지에서, 기존 등록된 정보를 확인하기 위해 호출하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 펫인 경우", content = @Content)
+    })
     Response<PetRegisterInfoDto> getPetRegisterInfo(UserDetailsImpl userDetails,
                                                     @PathVariable int petId);
 
@@ -61,6 +77,17 @@ public interface PetControllerApi {
             )
         }
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공"),
+            @ApiResponse(responseCode = "400", description = "1. 이미지 형식이 jpg, jpeg, png, gif, bmp, tiff 중 하나가 아닐 경우" +
+                    "\t\n 2. 비디오 형식이 mp4, avi, mov, wmv, flv, mkv, webm 중 하나가 아닐 경우" +
+                    "\t\n 3. 빈 이미지 파일일 경우" +
+                    "\t\n 4. 빈 비디오 파일일 경우" +
+                    "\t\n 5. 잘못된 나이 형식일 경우", content = @Content),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 펫 오류", content = @Content),
+            @ApiResponse(responseCode = "500", description = "S3 저장 오류", content = @Content)
+    })
+
     Response<UpdatePetSuccessDto> updatePet(
         UserDetailsImpl userDetails,
         @PathVariable int petId,
@@ -121,6 +148,9 @@ public interface PetControllerApi {
 
     @Operation(summary = "Pet 상세 조회",
         description = "")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 펫인 경우", content = @Content)
+    })
     Response<PetDto> getPetDetail(@PathVariable int petId);
 
 
@@ -136,6 +166,10 @@ public interface PetControllerApi {
             )
         }
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "404", description = "1. 존재하지 않는 펫인 경우" +
+                    "\t\n 2. 보호소를 찾을 수 없는 경우", content = @Content)
+    })
     Response<Void> updatePetAdopted(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                     @PathVariable int petId);
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
@@ -51,7 +51,7 @@ public class PetReadService {
     public PetDto getPetDetail(final int petId) {
         // petId로 Pet, PetPolygonProfile 얻어오기
         final Pet pet = petRepository.findById(petId)
-            .orElseThrow(() -> new PetNotFoundException());
+            .orElseThrow(PetNotFoundException::new);
 
         return PetDto.fromEntity(pet);
     }
@@ -63,7 +63,7 @@ public class PetReadService {
 
         // 펫 id로 Pet, PetPolygonProfile 얻어오기
         final Pet registerPet = petRepository.findById(petId)
-            .orElseThrow(() -> new PetNotFoundException());
+            .orElseThrow(PetNotFoundException::new);
 
         petValidator.validatePetUpdateAuthority(userDetails.getEmail(), registerPet);
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetWriteService.java
@@ -37,7 +37,7 @@ public class PetWriteService {
 
         // 펫 등록을 요청한 유저의 보호소 조회
         final Shelter shelter = shelterRepository.findByAccountEmail(userDetails.getEmail())
-            .orElseThrow(() -> new ShelterNotFoundException());
+            .orElseThrow(ShelterNotFoundException::new);
 
         final Pet registerPet = txManager.doPetRegisterTransaction(petRequestDTO, image, video, shelter);
 
@@ -54,7 +54,7 @@ public class PetWriteService {
 
         // 펫 id로 Pet 얻어오기
         final Pet updatePet = petRepository.findById(petId)
-            .orElseThrow(() -> new PetNotFoundException());
+            .orElseThrow(PetNotFoundException::new);
 
         petValidator.validatePetUpdateAuthority(userDetails.getEmail(), updatePet);
 
@@ -66,7 +66,7 @@ public class PetWriteService {
     public void updatePetAdopted(final UserDetailsImpl userDetails,
                                  final int petId) {
         final Pet pet = petRepository.findById(petId)
-            .orElseThrow(() -> new PetNotFoundException());
+            .orElseThrow(PetNotFoundException::new);
 
         petValidator.validatePetUpdateAuthority(userDetails.getEmail(), pet);
 

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -93,6 +95,10 @@ public interface ShelterControllerApi {
             )
         )
     )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "403", description = "내 보호소가 아닌 다른 보호소를 수정하려는 경우 권한이 없다.", content = @Content)
+    })
     @PostMapping("/filter")
     Response<List<ShelterLocationDto>> filterExistShelterListByLocationId(@RequestBody List<Integer> shelterLocationIdList);
 }


### PR DESCRIPTION
## 작업 내용
- swagger에 해당하는 예외만 나타나도록 수정 및 예외 명세 자세히
- 사용하지 않는 Custom Exception 삭제

## 공유하고 싶은 내용
- Swagger에서 @ApiResponse 작성 시 동일한 responseCode가 여러개 있을 경우 한개만 표시됩니다.

Close #182 