### PR TITLE
긴급 도움 페이지 조회 시 보호만료기간이 Null값인 경우 제외

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
@@ -70,7 +70,7 @@ public class PetController implements PetControllerApi {
 
     @GetMapping("/profiles/sos")
     public Response<SosPetProfilesDto> getPetSosProfiles(
-        @PageableDefault(page = 1, size = 8, sort = "protectionExpirationDate", direction = Sort.Direction.ASC) final Pageable pageable) {
+        @PageableDefault(page = 1, size = 8) final Pageable pageable) {
         return Response.success(petReadService.getPetSosProfiles(pageable));
     }
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
@@ -31,15 +31,13 @@ public interface PetRepository extends JpaRepository<Pet, Integer> {
     Page<Pet> findByShelterId(Integer shelterId, Pageable pageable);
 
     @Query(value = "SELECT p FROM Pet p"
-        + " JOIN FETCH p.shelter"
         + " WHERE p.protectionExpirationDate IS NOT NULL"
         + " ORDER BY p.protectionExpirationDate ASC")
-    List<Pet> findProfilesWithProtectionExpirationDate(Pageable pageable);
+    Page<Pet> findProfilesWithProtectionExpirationDate(Pageable pageable);
 
     @Query(value = "SELECT p FROM Pet p"
-        + " JOIN FETCH p.shelter"
         + " ORDER BY p.createdAt DESC")
-    List<Pet> findProfilesWithCreatedAt(Pageable pageable);
+    Page<Pet> findProfilesWithCreatedAt(Pageable pageable);
 
     @Query(value = "SELECT p FROM Pet p"
         + " JOIN FETCH p.shelter"

--- a/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
@@ -31,8 +31,9 @@ public interface PetRepository extends JpaRepository<Pet, Integer> {
     Page<Pet> findByShelterId(Integer shelterId, Pageable pageable);
 
     @Query(value = "SELECT p FROM Pet p"
-        + " WHERE p.protectionExpirationDate IS NOT NULL"
-        + " ORDER BY p.protectionExpirationDate ASC")
+            + " WHERE p.protectionExpirationDate IS NOT NULL"
+            + " AND p.protectionExpirationDate >= CURRENT_DATE"
+            + " ORDER BY p.protectionExpirationDate ASC")
     Page<Pet> findProfilesWithProtectionExpirationDate(Pageable pageable);
 
     @Query(value = "SELECT p FROM Pet p"

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
@@ -25,8 +25,8 @@ public class PetReadService {
 
     public PetProfilesDto getPetProfiles() {
         // sos, new 프로필 각각 최대 8개씩 조회
-        final List<Pet> sosProfiles = petRepository.findProfilesWithProtectionExpirationDate(PageRequest.of(0, 8));
-        final List<Pet> newProfiles = petRepository.findProfilesWithCreatedAt(PageRequest.of(0, 8));
+        final List<Pet> sosProfiles = petRepository.findProfilesWithProtectionExpirationDate(PageRequest.of(0, 8)).getContent();
+        final List<Pet> newProfiles = petRepository.findProfilesWithCreatedAt(PageRequest.of(0, 8)).getContent();
 
         // DTO에 넣어주기
         final List<SosPetDto> sosList = sosProfiles.stream()
@@ -41,11 +41,11 @@ public class PetReadService {
     }
 
     public SosPetProfilesDto getPetSosProfiles(final Pageable pageable) {
-        return SosPetProfilesDto.of(petRepository.findPageBy(pageable));
+        return SosPetProfilesDto.of(petRepository.findProfilesWithProtectionExpirationDate(pageable));
     }
 
     public NewPetProfilesDto getPetNewProfiles(final Pageable pageable) {
-        return NewPetProfilesDto.of(petRepository.findPageBy(pageable));
+        return NewPetProfilesDto.of(petRepository.findProfilesWithCreatedAt(pageable));
     }
 
     public PetDto getPetDetail(final int petId) {

--- a/animory/src/test/java/com/daggle/animory/domain/pet/PetRepositoryTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/pet/PetRepositoryTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
@@ -42,4 +43,28 @@ class PetRepositoryTest extends DataJpaTestWithDummyData {
                 p -> assertThat(p.getShelter().getId()).isEqualTo(shelterId)
         );
     }
+
+    @Test
+    void findProfilesWithProtectionExpirationDate() {
+        final List<Pet> page = petRepository.findProfilesWithProtectionExpirationDate(PageRequest.of(0, 10)).getContent();
+
+        print(page);
+
+        page.forEach(
+                p -> System.out.println(p.getId() + " " + p.getProtectionExpirationDate())
+        );
+    }
+
+    @Test
+    void findPage() {
+        final List<Pet> page = petRepository.findPageBy(PageRequest.of(0, 10, Sort.Direction.ASC, "protectionExpirationDate")).getContent();
+
+        print(page);
+
+        page.forEach(
+                p -> System.out.println(p.getId() + " " + p.getProtectionExpirationDate())
+        );
+
+    }
+
 }

--- a/animory/src/test/java/com/daggle/animory/testutil/datajpatest/DataJpaTestWithDummyData.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/datajpatest/DataJpaTestWithDummyData.java
@@ -48,5 +48,9 @@ public abstract class DataJpaTestWithDummyData extends WithTimeSupportObjectMapp
 
         petRepository.saveAll(pets);
         petRepository.saveAll(petsOfOtherShelter);
+
+        petRepository.saveAll(PetFixture.getRandomProtectionExpirationDate(5, shelters.get(0)));
+        petRepository.saveAll(PetFixture.getNullProtectionExpirationDate(5, shelters.get(0)));
+
     }
 }

--- a/animory/src/test/java/com/daggle/animory/testutil/fixture/PetFixture.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/fixture/PetFixture.java
@@ -72,4 +72,72 @@ public class PetFixture {
         }
         return pets;
     }
+    public static List<Pet> getRandomProtectionExpirationDate(final int n,
+                                final Shelter shelter) {
+        final List<Pet> pets = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            pets.add(
+                    Pet.builder()
+                            .name("멍멍이" + i)
+                            .birthDate(LocalDate.now().minusMonths(6))
+                            .type(PetType.DOG)
+                            .weight(5.0f)
+                            .description("멍멍이는 귀여워요" + i)
+                            .sex(Sex.MALE)
+                            .protectionExpirationDate(LocalDate.of(2023, (int) (Math.random() * 11) + 1, (int) (Math.random() * 30) + 1))
+                            .vaccinationStatus("접종완료" + i)
+                            .neutralizationStatus(NeutralizationStatus.UNKNOWN)
+                            .adoptionStatus(AdoptionStatus.NO)
+                            .profileImageUrl("http://amazon.server/api/petImage/20231001104521_test" + i + ".jpg")
+                            .profileShortFormUrl("http://amazon.server/api/petVideo/20231001104521_test" + i + ".mp4")
+                            .size("작아요 소형견입니다." + i)
+                            .petPolygonProfile(
+                                    PetPolygonProfile.builder()
+                                            .activeness(3)
+                                            .intelligence(3)
+                                            .affinity(2)
+                                            .adaptability(4)
+                                            .athletic(1)
+                                            .build()
+                            )
+                            .shelter(shelter)
+                            .build()
+            );
+        }
+        return pets;
+    }
+    public static List<Pet> getNullProtectionExpirationDate(final int n,
+                                                              final Shelter shelter) {
+        final List<Pet> pets = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            pets.add(
+                    Pet.builder()
+                            .name("멍멍이" + i)
+                            .birthDate(LocalDate.now().minusMonths(6))
+                            .type(PetType.DOG)
+                            .weight(5.0f)
+                            .description("멍멍이는 귀여워요" + i)
+                            .sex(Sex.MALE)
+                            .vaccinationStatus("접종완료" + i)
+                            .neutralizationStatus(NeutralizationStatus.UNKNOWN)
+                            .protectionExpirationDate(null)
+                            .adoptionStatus(AdoptionStatus.NO)
+                            .profileImageUrl("http://amazon.server/api/petImage/20231001104521_test" + i + ".jpg")
+                            .profileShortFormUrl("http://amazon.server/api/petVideo/20231001104521_test" + i + ".mp4")
+                            .size("작아요 소형견입니다." + i)
+                            .petPolygonProfile(
+                                    PetPolygonProfile.builder()
+                                            .activeness(3)
+                                            .intelligence(3)
+                                            .affinity(2)
+                                            .adaptability(4)
+                                            .athletic(1)
+                                            .build()
+                            )
+                            .shelter(shelter)
+                            .build()
+            );
+        }
+        return pets;
+    }
 }


### PR DESCRIPTION
## 작업 내용
- 긴급 도움 페이지 조회 시 보호만료기간이 Null값인 경우 제외하도록 @Pageable 에서 sort 제외

## 논의하고 싶은 내용
- 추가로, 2021.03.04 처럼 now() 기준으로 보호만료기간이 지난 경우는 조회되지 않도록 했습니다. 

Close #197 