### PR TITLE
PageableDefault, 변경된 DB 구조, 이전 테스트 실패 등에 관련한 각종 BugFix

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetController.java
@@ -10,7 +10,6 @@ import com.daggle.animory.domain.pet.service.PetWriteService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -70,13 +69,13 @@ public class PetController implements PetControllerApi {
 
     @GetMapping("/profiles/sos")
     public Response<SosPetProfilesDto> getPetSosProfiles(
-        @PageableDefault(page = 1, size = 8) final Pageable pageable) {
+        @PageableDefault(size = 8) final Pageable pageable) {
         return Response.success(petReadService.getPetSosProfiles(pageable));
     }
 
     @GetMapping("/profiles/new")
     public Response<NewPetProfilesDto> getPetNewProfiles(
-        @PageableDefault(page = 1, size = 8, sort = "createdAt", direction = Direction.DESC) final Pageable pageable) {
+        @PageableDefault(size = 8, sort = "createdAt", direction = Direction.DESC) final Pageable pageable) {
         return Response.success(petReadService.getPetNewProfiles(pageable));
     }
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/controller/PetControllerApi.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,7 +27,8 @@ import org.springframework.web.multipart.MultipartFile;
 public interface PetControllerApi {
 
     @Operation(summary = "[로그인 필요: 보호소] Pet 등록 요청",
-        description = "Pet 등록 요청 API 입니다. Swagger Test가 작동하지 않을 수 있습니다.(https://github.com/springdoc/springdoc-openapi/issues/820)",
+        description = "Pet 등록 요청 API 입니다. Swagger Test가 작동하지 않을 수 있습니다.(https://github" +
+            ".com/springdoc/springdoc-openapi/issues/820)",
         parameters = {
             @Parameter(
                 in = ParameterIn.HEADER,
@@ -40,14 +40,14 @@ public interface PetControllerApi {
         }
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "저장 성공"),
-            @ApiResponse(responseCode = "400", description = "1. 이미지 형식이 jpg, jpeg, png, gif, bmp, tiff 중 하나가 아닐 경우" +
-                    "\t\n 2. 비디오 형식이 mp4, avi, mov, wmv, flv, mkv, webm 중 하나가 아닐 경우" +
-                    "\t\n 3. 빈 이미지 파일일 경우" +
-                    "\t\n 4. 빈 비디오 파일일 경우" +
-                    "\t\n 5. 잘못된 나이 형식일 경우", content = @Content),
-            @ApiResponse(responseCode = "404", description = "보호소를 찾을 수 없는 경우", content = @Content),
-            @ApiResponse(responseCode = "500", description = "S3 저장 오류", content = @Content)
+        @ApiResponse(responseCode = "200", description = "저장 성공"),
+        @ApiResponse(responseCode = "400", description = "1. 이미지 형식이 jpg, jpeg, png, gif, bmp, tiff 중 하나가 아닐 경우" +
+            "\t\n 2. 비디오 형식이 mp4, avi, mov, wmv, flv, mkv, webm 중 하나가 아닐 경우" +
+            "\t\n 3. 빈 이미지 파일일 경우" +
+            "\t\n 4. 빈 비디오 파일일 경우" +
+            "\t\n 5. 잘못된 나이 형식일 경우", content = @Content),
+        @ApiResponse(responseCode = "404", description = "보호소를 찾을 수 없는 경우", content = @Content),
+        @ApiResponse(responseCode = "500", description = "S3 저장 오류", content = @Content)
     })
     Response<RegisterPetSuccessDto> registerPet(
         UserDetailsImpl userDetails,
@@ -59,14 +59,15 @@ public interface PetControllerApi {
     @Operation(summary = "Pet 수정 페이지 진입, 기존 펫 정보 확인",
         description = "Pet 수정 페이지에서, 기존 등록된 정보를 확인하기 위해 호출하는 API 입니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 펫인 경우", content = @Content)
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 펫인 경우", content = @Content)
     })
     Response<PetRegisterInfoDto> getPetRegisterInfo(UserDetailsImpl userDetails,
                                                     @PathVariable int petId);
 
     // Pet 수정 요청
     @Operation(summary = "[로그인 필요: 보호소] Pet 수정 요청",
-        description = "보호소 계정 권한이 필요합니다. Swagger Test가 작동하지 않을 수 있습니다.(https://github.com/springdoc/springdoc-openapi/issues/820)",
+        description = "보호소 계정 권한이 필요합니다. Swagger Test가 작동하지 않을 수 있습니다.(https://github" +
+            ".com/springdoc/springdoc-openapi/issues/820)",
         parameters = {
             @Parameter(
                 in = ParameterIn.HEADER,
@@ -78,16 +79,15 @@ public interface PetControllerApi {
         }
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "저장 성공"),
-            @ApiResponse(responseCode = "400", description = "1. 이미지 형식이 jpg, jpeg, png, gif, bmp, tiff 중 하나가 아닐 경우" +
-                    "\t\n 2. 비디오 형식이 mp4, avi, mov, wmv, flv, mkv, webm 중 하나가 아닐 경우" +
-                    "\t\n 3. 빈 이미지 파일일 경우" +
-                    "\t\n 4. 빈 비디오 파일일 경우" +
-                    "\t\n 5. 잘못된 나이 형식일 경우", content = @Content),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 펫 오류", content = @Content),
-            @ApiResponse(responseCode = "500", description = "S3 저장 오류", content = @Content)
+        @ApiResponse(responseCode = "200", description = "저장 성공"),
+        @ApiResponse(responseCode = "400", description = "1. 이미지 형식이 jpg, jpeg, png, gif, bmp, tiff 중 하나가 아닐 경우" +
+            "\t\n 2. 비디오 형식이 mp4, avi, mov, wmv, flv, mkv, webm 중 하나가 아닐 경우" +
+            "\t\n 3. 빈 이미지 파일일 경우" +
+            "\t\n 4. 빈 비디오 파일일 경우" +
+            "\t\n 5. 잘못된 나이 형식일 경우", content = @Content),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 펫 오류", content = @Content),
+        @ApiResponse(responseCode = "500", description = "S3 저장 오류", content = @Content)
     })
-
     Response<UpdatePetSuccessDto> updatePet(
         UserDetailsImpl userDetails,
         @PathVariable int petId,
@@ -121,7 +121,7 @@ public interface PetControllerApi {
     )
     Response<SosPetProfilesDto> getPetSosProfiles(
         @Parameter(hidden = true)
-        @PageableDefault(page = 1, size = 8, sort = "protectionExpirationDate", direction = Sort.Direction.ASC) Pageable pageable);
+        @PageableDefault(size = 8) Pageable pageable);
 
     @Operation(summary = "Pet New 목록 조회",
         description = "신규 등록 Pet 목록 입니다.",
@@ -144,12 +144,12 @@ public interface PetControllerApi {
     )
     Response<NewPetProfilesDto> getPetNewProfiles(
         @Parameter(hidden = true)
-        @PageableDefault(page = 1, size = 8, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable);
+        @PageableDefault(size = 8) Pageable pageable);
 
     @Operation(summary = "Pet 상세 조회",
         description = "")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 펫인 경우", content = @Content)
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 펫인 경우", content = @Content)
     })
     Response<PetDto> getPetDetail(@PathVariable int petId);
 
@@ -167,8 +167,8 @@ public interface PetControllerApi {
         }
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "404", description = "1. 존재하지 않는 펫인 경우" +
-                    "\t\n 2. 보호소를 찾을 수 없는 경우", content = @Content)
+        @ApiResponse(responseCode = "404", description = "1. 존재하지 않는 펫인 경우" +
+            "\t\n 2. 보호소를 찾을 수 없는 경우", content = @Content)
     })
     Response<Void> updatePetAdopted(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                     @PathVariable int petId);

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
@@ -5,6 +5,7 @@ import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
 import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
 import com.daggle.animory.domain.shelter.entity.Shelter;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -62,7 +63,8 @@ public class Pet extends BaseEntity {
     @NotNull
     private String profileImageUrl;
 
-    @Getter(AccessLevel.NONE) // 여러 개의 Pet Video를 가지는 UseCase가 정의되고 나면 사용하기 위해, 실수 방지 차원에서 접근을 제거해두겠습니다.
+    @Getter(value = AccessLevel.NONE) // 여러 개의 Pet Video를 가지는 UseCase가 정의되고 나면 사용하기 위해, 실수 방지 차원에서 접근을 제거해두겠습니다.
+    @JsonManagedReference
     @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<PetVideo> petVideos;
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/Pet.java
@@ -5,7 +5,10 @@ import com.daggle.animory.domain.pet.dto.request.PetUpdateRequestDto;
 import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
 import com.daggle.animory.domain.shelter.entity.Shelter;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -14,8 +17,6 @@ import java.util.List;
 
 @Getter
 @Entity
-@Builder
-@AllArgsConstructor
 @Table(name = "pet")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Pet extends BaseEntity {
@@ -72,6 +73,31 @@ public class Pet extends BaseEntity {
     @JoinColumn(name = "shelter_id")
     private Shelter shelter;
 
+    @Builder
+    public Pet(final String name, final LocalDate birthDate, final PetType type, final float weight,
+               final Sex sex, final String description, final LocalDate protectionExpirationDate,
+               final String vaccinationStatus, final NeutralizationStatus neutralizationStatus,
+               final AdoptionStatus adoptionStatus, final String profileImageUrl, final List<PetVideo> petVideos,
+               final String size, final PetPolygonProfile petPolygonProfile, final Shelter shelter) {
+        this.name = name;
+        this.birthDate = birthDate;
+        this.type = type;
+        this.weight = weight;
+        this.sex = sex;
+        this.description = description;
+        this.protectionExpirationDate = protectionExpirationDate;
+        this.vaccinationStatus = vaccinationStatus;
+        this.neutralizationStatus = neutralizationStatus;
+        this.adoptionStatus = adoptionStatus;
+        this.profileImageUrl = profileImageUrl;
+        this.petVideos = petVideos;
+        petVideos.forEach(petVideo -> petVideo.setPet(this));
+        this.size = size;
+        this.petPolygonProfile = petPolygonProfile;
+        this.shelter = shelter;
+    }
+
+
     public void setAdopted() {
         this.adoptionStatus = AdoptionStatus.YES;
         this.protectionExpirationDate = null;
@@ -92,8 +118,10 @@ public class Pet extends BaseEntity {
         this.description = petUpdateRequestDto.description();
     }
 
+    // 현재는 UX 상 Pet은 1개의 동영상만 가지고 있는다.
     public PetVideo getPetVideo() {
         return petVideos.get(0);
     }
+
 
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetVideo.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetVideo.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.domain.pet.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.*;
 
 import javax.persistence.*;
@@ -24,6 +25,7 @@ public class PetVideo {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pet_id")
+    @JsonBackReference
     private Pet pet;
 
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetVideo.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetVideo.java
@@ -21,7 +21,7 @@ public class PetVideo {
 
     @NotNull
     private int likeCount;
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pet_id")
     private Pet pet;
@@ -34,4 +34,7 @@ public class PetVideo {
         this.pet = pet;
     }
 
+    public void setPet(final Pet pet) {
+        this.pet = pet;
+    }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface PetRepository extends JpaRepository<Pet, Integer> {
@@ -21,6 +20,10 @@ public interface PetRepository extends JpaRepository<Pet, Integer> {
         "and p.type = :petType")
     Slice<Pet> findSliceBy(PetType petType, Province province, Pageable searchCondition);
 
+    @Query("select p " +
+        "from Pet p " +
+        "join fetch p.shelter s " +
+        "join fetch p.petVideos pv ")
     Slice<Pet> findSliceBy(Pageable pageable);
 
     Page<Pet> findPageBy(Pageable pageable);
@@ -31,9 +34,9 @@ public interface PetRepository extends JpaRepository<Pet, Integer> {
     Page<Pet> findByShelterId(Integer shelterId, Pageable pageable);
 
     @Query(value = "SELECT p FROM Pet p"
-            + " WHERE p.protectionExpirationDate IS NOT NULL"
-            + " AND p.protectionExpirationDate >= CURRENT_DATE"
-            + " ORDER BY p.protectionExpirationDate ASC")
+        + " WHERE p.protectionExpirationDate IS NOT NULL"
+        + " AND p.protectionExpirationDate >= CURRENT_DATE"
+        + " ORDER BY p.protectionExpirationDate ASC")
     Page<Pet> findProfilesWithProtectionExpirationDate(Pageable pageable);
 
     @Query(value = "SELECT p FROM Pet p"

--- a/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/repository/PetRepository.java
@@ -1,30 +1,14 @@
 package com.daggle.animory.domain.pet.repository;
 
 import com.daggle.animory.domain.pet.entity.Pet;
-import com.daggle.animory.domain.pet.entity.PetType;
-import com.daggle.animory.domain.shelter.entity.Province;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface PetRepository extends JpaRepository<Pet, Integer> {
-
-    @Query("select p " +
-        "from Pet p " +
-        "join fetch p.shelter s " +
-        "where s.address.province = :province " +
-        "and p.type = :petType")
-    Slice<Pet> findSliceBy(PetType petType, Province province, Pageable searchCondition);
-
-    @Query("select p " +
-        "from Pet p " +
-        "join fetch p.shelter s " +
-        "join fetch p.petVideos pv ")
-    Slice<Pet> findSliceBy(Pageable pageable);
 
     Page<Pet> findPageBy(Pageable pageable);
 

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterController.java
@@ -27,7 +27,7 @@ public class ShelterController implements ShelterControllerApi {
     @Override
     @GetMapping("/{shelterId}")
     public Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) final Integer shelterId,
-                                                   @PageableDefault(page = 1, size = 10) final Pageable pageable) {
+                                                   @PageableDefault final Pageable pageable) {
         return Response.success(shelterService.getShelterProfile(shelterId, pageable));
     }
 

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/controller/ShelterControllerApi.java
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,8 +23,8 @@ import javax.validation.constraints.Min;
 import java.util.List;
 
 @Tag(name = "보호소 API", description = """
-    최종수정시각: 2023-10-22 23:44
-""")
+        최종수정시각: 2023-10-22 23:44
+    """)
 public interface ShelterControllerApi {
 
     @Operation(summary = "보호소 프로필 조회", description = "보호소 프로필을 조회합니다.",
@@ -50,7 +49,7 @@ public interface ShelterControllerApi {
     Response<ShelterProfilePage> getShelter(@PathVariable @Min(0) Integer shelterId,
 
                                             @Parameter(hidden = true)
-                                            @PageableDefault(page = 1, size = 10) Pageable pageable);
+                                            Pageable pageable);
 
     @Operation(summary = "[로그인 필요: 보호소] 보호소 정보 수정", description = "보호소 정보를 수정합니다.",
         parameters = {
@@ -83,7 +82,8 @@ public interface ShelterControllerApi {
                                                     @PathVariable @Min(0) Integer shelterId,
                                                     @RequestBody ShelterUpdateDto shelterUpdateDto);
 
-    @Operation(summary = "등록된 보호소 필터링", description = "검색된 보호소의 KakaoLocationID 배열을 입력받아서, DB에서 KakaoLocationId가 일치하는 보호소 정보를 목록으로 반환합니다.",
+    @Operation(summary = "등록된 보호소 필터링", description = "검색된 보호소의 KakaoLocationID 배열을 입력받아서, DB에서 KakaoLocationId가 일치하는" +
+        " 보호소 정보를 목록으로 반환합니다.",
         requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = "서비스 등록 여부를 확인하고자 하는 보호소들의 KakaoLocation ID 배열",
             required = true,
@@ -96,8 +96,8 @@ public interface ShelterControllerApi {
         )
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
-            @ApiResponse(responseCode = "403", description = "내 보호소가 아닌 다른 보호소를 수정하려는 경우 권한이 없다.", content = @Content)
+        @ApiResponse(responseCode = "200", description = "회원가입 성공"),
+        @ApiResponse(responseCode = "403", description = "내 보호소가 아닌 다른 보호소를 수정하려는 경우 권한이 없다.", content = @Content)
     })
     @PostMapping("/filter")
     Response<List<ShelterLocationDto>> filterExistShelterListByLocationId(@RequestBody List<Integer> shelterLocationIdList);

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Shelter.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Shelter.java
@@ -27,7 +27,7 @@ public class Shelter extends BaseEntity {
     @Embedded
     private ShelterAddress address;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "account_id")
     private Account account;
 

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
@@ -8,9 +8,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ShortFormService {
 

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
@@ -1,9 +1,9 @@
 package com.daggle.animory.domain.shortform;
 
-import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shortform.dto.request.ShortFormSearchCondition;
 import com.daggle.animory.domain.shortform.dto.response.CategoryShortFormPage;
 import com.daggle.animory.domain.shortform.dto.response.HomeShortFormPage;
+import com.daggle.animory.domain.shortform.repository.PetVideoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -16,13 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ShortFormService {
 
-    private final PetRepository petRepository;
+    private final PetVideoRepository petVideoRepository;
 
     public CategoryShortFormPage getCategoryShortFormPage(final ShortFormSearchCondition searchCondition,
                                                           final Pageable pageable) {
         return CategoryShortFormPage.of(
             buildCategoryPageTitle(searchCondition),
-            petRepository.findSliceBy(
+            petVideoRepository.findSliceBy(
                 searchCondition.type(),
                 searchCondition.area(),
                 pageable
@@ -33,7 +33,7 @@ public class ShortFormService {
     public HomeShortFormPage getHomeShortFormPage(final Pageable pageable) {
         // TODO: 홈 화면 숏폼 영상은 어떤 순서, 어떤 기준으로 보여줄 것인가?
         return HomeShortFormPage.of(
-            petRepository.findSliceBy(pageable) // TODO: 하드코딩된 Page 숫자
+            petVideoRepository.findSliceBy(pageable) // TODO: 하드코딩된 Page 숫자
         );
     }
 

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormController.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormController.java
@@ -28,7 +28,7 @@ public class ShortFormController implements ShortFormControllerApi {
     @Override
     @GetMapping("/short-forms")
     public Response<CategoryShortFormPage> getShortForms(@ModelAttribute @Valid final ShortFormSearchCondition searchCondition,
-                                                         @PageableDefault(page = 1, size = 10) final Pageable pageable) {
+                                                         @PageableDefault final Pageable pageable) {
         return Response.success(shortFormService.getCategoryShortFormPage(searchCondition, pageable));
     }
 
@@ -36,7 +36,7 @@ public class ShortFormController implements ShortFormControllerApi {
      * 홈 화면에서 보여 줄 숏폼 영상들을 조회합니다.
      */
     @GetMapping("/short-forms/home")
-    public Response<HomeShortFormPage> getHomeShortForms(@PageableDefault(page = 1, size = 10) final Pageable pageable) {
+    public Response<HomeShortFormPage> getHomeShortForms(@PageableDefault final Pageable pageable) {
         return Response.success(shortFormService.getHomeShortFormPage(pageable));
     }
 

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
@@ -85,6 +85,6 @@ public interface ShortFormControllerApi {
         }
     )
     @GetMapping("/short-forms/home")
-    Response<HomeShortFormPage> getHomeShortForms(@PageableDefault Pageable pageable);
+    Response<HomeShortFormPage> getHomeShortForms(@Parameter(hidden = true) @PageableDefault Pageable pageable);
 
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/controller/ShortFormControllerApi.java
@@ -21,8 +21,8 @@ import javax.validation.Valid;
 @Tag(
     name = "숏폼 비디오 API",
     description = """
-        최종수정시각: 2023-10-22 23:24
-    """
+            최종수정시각: 2023-10-22 23:24
+        """
 )
 public interface ShortFormControllerApi {
 
@@ -63,7 +63,7 @@ public interface ShortFormControllerApi {
     Response<CategoryShortFormPage> getShortForms(@Parameter(hidden = true)
                                                   @ModelAttribute @Valid ShortFormSearchCondition searchCondition,
                                                   @Parameter(hidden = true) // 문서에 깔끔하게 나오지 않을 경우, 이런 식으로 그냥 숨겨버립니다.
-                                                  @PageableDefault(page = 1, size = 10) Pageable pageable);
+                                                  @PageableDefault Pageable pageable);
 
     @Operation(summary = "홈 화면 숏폼 비디오 조회",
         description = "홈 화면에서 보여 줄 숏폼 비디오들을 조회합니다.",
@@ -85,6 +85,6 @@ public interface ShortFormControllerApi {
         }
     )
     @GetMapping("/short-forms/home")
-    Response<HomeShortFormPage> getHomeShortForms(@PageableDefault(page = 1, size = 10) Pageable pageable);
+    Response<HomeShortFormPage> getHomeShortForms(@PageableDefault Pageable pageable);
 
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/repository/PetVideoRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/repository/PetVideoRepository.java
@@ -1,0 +1,25 @@
+package com.daggle.animory.domain.shortform.repository;
+
+import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.shelter.entity.Province;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PetVideoRepository extends JpaRepository<Pet, Integer> {
+    @Query("select p " +
+        "from Pet p " +
+        "join fetch p.shelter s " +
+        "join fetch p.petVideos pv ")
+    Slice<Pet> findSliceBy(Pageable pageable);
+
+    @Query("select p " +
+        "from Pet p " +
+        "join fetch p.shelter s " +
+        "join fetch p.petVideos pv " +
+        "where s.address.province = :province " +
+        "and p.type = :petType")
+    Slice<Pet> findSliceBy(PetType petType, Province province, Pageable searchCondition);
+}

--- a/animory/src/main/resources/application-production.yml
+++ b/animory/src/main/resources/application-production.yml
@@ -21,6 +21,7 @@ spring:
     hibernate.ddl-auto: validate
     properties:
       hibernate.format_sql: true
+  data.web.pageable.one-indexed-parameters: true # Request로 들어오는 Pageable 의 인덱스를 1부터 시작하도록 설정합니다.
   # DB Scheme History Management
   flyway:
     url: ${DATABASE_URL}?allowPublicKeyRetrieval=true&useSSL=false

--- a/animory/src/test/java/com/daggle/animory/domain/pet/PetRepositoryTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/pet/PetRepositoryTest.java
@@ -1,15 +1,12 @@
 package com.daggle.animory.domain.pet;
 
 import com.daggle.animory.domain.pet.entity.Pet;
-import com.daggle.animory.domain.pet.entity.PetType;
 import com.daggle.animory.domain.pet.repository.PetRepository;
-import com.daggle.animory.domain.shelter.entity.Province;
 import com.daggle.animory.testutil.datajpatest.DataJpaTestWithDummyData;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -23,15 +20,6 @@ class PetRepositoryTest extends DataJpaTestWithDummyData {
     private PetRepository petRepository;
 
     @Test
-    void findSliceBy() {
-        final Slice<Pet> slice = petRepository.findSliceBy(PetType.DOG, Province.광주, PageRequest.of(0, 10));
-
-        print(slice.getContent());
-
-        assertThat(slice.getContent()).hasSize(10);
-    }
-
-    @Test
     void findByShelterId() {
         final Integer shelterId = 1;
         final Page<Pet> page = petRepository.findByShelterId(shelterId, PageRequest.of(0, 10));
@@ -40,29 +28,31 @@ class PetRepositoryTest extends DataJpaTestWithDummyData {
         print(pets);
 
         pets.forEach(
-                p -> assertThat(p.getShelter().getId()).isEqualTo(shelterId)
+            p -> assertThat(p.getShelter().getId()).isEqualTo(shelterId)
         );
     }
 
     @Test
     void findProfilesWithProtectionExpirationDate() {
-        final List<Pet> page = petRepository.findProfilesWithProtectionExpirationDate(PageRequest.of(0, 10)).getContent();
+        final List<Pet> page =
+            petRepository.findProfilesWithProtectionExpirationDate(PageRequest.of(0, 10)).getContent();
 
         print(page);
 
         page.forEach(
-                p -> System.out.println(p.getId() + " " + p.getProtectionExpirationDate())
+            p -> System.out.println(p.getId() + " " + p.getProtectionExpirationDate())
         );
     }
 
     @Test
     void findPage() {
-        final List<Pet> page = petRepository.findPageBy(PageRequest.of(0, 10, Sort.Direction.ASC, "protectionExpirationDate")).getContent();
+        final List<Pet> page = petRepository.findPageBy(PageRequest.of(0, 10, Sort.Direction.ASC,
+                                                                       "protectionExpirationDate")).getContent();
 
         print(page);
 
         page.forEach(
-                p -> System.out.println(p.getId() + " " + p.getProtectionExpirationDate())
+            p -> System.out.println(p.getId() + " " + p.getProtectionExpirationDate())
         );
 
     }

--- a/animory/src/test/java/com/daggle/animory/domain/pet/util/PetAgeToBirthDateConverterTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/pet/util/PetAgeToBirthDateConverterTest.java
@@ -49,7 +49,7 @@ class PetAgeToBirthDateConverterTest {
 
         final LocalDate now = LocalDate.now();
         final LocalDate expectedBirthDate = now.minusYears(birthDate.getYear()).minusMonths(birthDate.getMonthValue());
-        final String expectedAge = expectedBirthDate.getYear() + "년" + expectedBirthDate.getMonthValue() + "개월";
+        final String expectedAge = getExpectedAge(expectedBirthDate);
 
         log.debug("\n birthDate: {},\n expectedAge: {},\n calculatedAge: {}", birthDate, expectedAge, calculatedAge);
 
@@ -63,6 +63,12 @@ class PetAgeToBirthDateConverterTest {
         final String age = PetAgeToBirthDateConverter.birthDateToAge(birthDate);
 
         assertThat(age).isEqualTo("1개월");
+    }
+
+    private static String getExpectedAge(final LocalDate expectedBirthDate) {
+        return expectedBirthDate.getYear() == 0 ?
+            expectedBirthDate.getMonthValue() + "개월" :
+            expectedBirthDate.getYear() + "년" + expectedBirthDate.getMonthValue() + "개월";
     }
 
     private void assertEqualsBirthDate(final LocalDate birthDate, final int year, final int month) {

--- a/animory/src/test/java/com/daggle/animory/domain/shortform/ShortFormRepositoryTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shortform/ShortFormRepositoryTest.java
@@ -1,0 +1,28 @@
+package com.daggle.animory.domain.shortform;
+
+import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.shelter.entity.Province;
+import com.daggle.animory.domain.shortform.repository.PetVideoRepository;
+import com.daggle.animory.testutil.datajpatest.DataJpaTestWithDummyData;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShortFormRepositoryTest extends DataJpaTestWithDummyData {
+
+    @Autowired
+    private PetVideoRepository petVideoRepository;
+
+    @Test
+    void findSliceBy() {
+        final Slice<Pet> slice = petVideoRepository.findSliceBy(PetType.DOG, Province.광주, PageRequest.of(0, 10));
+
+        print(slice.getContent());
+
+        assertThat(slice.getContent()).hasSize(10);
+    }
+}

--- a/animory/src/test/java/com/daggle/animory/testutil/WithTimeSupportObjectMapper.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/WithTimeSupportObjectMapper.java
@@ -16,10 +16,11 @@ public abstract class WithTimeSupportObjectMapper {
         .registerModule(new JavaTimeModule());
 
     protected void print(final Object o) {
-        try{
+        try {
             log.debug(om.writerWithDefaultPrettyPrinter().writeValueAsString(o));
-        } catch (final JsonProcessingException e){
+        } catch (final JsonProcessingException e) {
             log.debug("json parsing error: " + e.getMessage());
+            throw new RuntimeException(e);
         }
     }
 

--- a/animory/src/test/java/com/daggle/animory/testutil/datajpatest/DataJpaTestWithDummyData.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/datajpatest/DataJpaTestWithDummyData.java
@@ -3,16 +3,17 @@ package com.daggle.animory.testutil.datajpatest;
 
 import com.daggle.animory.domain.account.AccountRepository;
 import com.daggle.animory.domain.account.entity.Account;
-import com.daggle.animory.testutil.fixture.AccountFixture;
-import com.daggle.animory.testutil.fixture.ShelterFixture;
-import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetType;
-import com.daggle.animory.testutil.fixture.PetFixture;
+import com.daggle.animory.domain.pet.repository.PetRepository;
 import com.daggle.animory.domain.shelter.ShelterRepository;
 import com.daggle.animory.domain.shelter.entity.Province;
 import com.daggle.animory.domain.shelter.entity.Shelter;
 import com.daggle.animory.testutil.WithTimeSupportObjectMapper;
+import com.daggle.animory.testutil.fixture.AccountFixture;
+import com.daggle.animory.testutil.fixture.PetFixture;
+import com.daggle.animory.testutil.fixture.ShelterFixture;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -20,6 +21,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.List;
 
+@Slf4j
 @DataJpaTest
 @EnableJpaAuditing
 public abstract class DataJpaTestWithDummyData extends WithTimeSupportObjectMapper {
@@ -39,9 +41,15 @@ public abstract class DataJpaTestWithDummyData extends WithTimeSupportObjectMapp
 
         accountRepository.save(shelter);
 
+        log.debug("Account Saved");
+        printDelimiter();
+
         final List<Shelter> shelters = ShelterFixture.get(5, Province.광주, shelter);
 
         shelterRepository.saveAll(shelters);
+
+        log.debug("Shelter Saved");
+        printDelimiter();
 
         final List<Pet> pets = PetFixture.get(20, PetType.DOG, shelters.get(0)); // shelter province = 광주
         final List<Pet> petsOfOtherShelter = PetFixture.get(10, PetType.DOG, shelters.get(1)); // shelter province = 광주
@@ -52,5 +60,13 @@ public abstract class DataJpaTestWithDummyData extends WithTimeSupportObjectMapp
         petRepository.saveAll(PetFixture.getRandomProtectionExpirationDate(5, shelters.get(0)));
         petRepository.saveAll(PetFixture.getNullProtectionExpirationDate(5, shelters.get(0)));
 
+        log.debug("Pet Saved");
+        printDelimiter();
+    }
+
+    private void printDelimiter() {
+        for (int i = 0; i < 10; i++) {
+            log.debug("----------------------------------------------------------------");
+        }
     }
 }

--- a/animory/src/test/java/com/daggle/animory/testutil/fixture/PetFixture.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/fixture/PetFixture.java
@@ -4,6 +4,7 @@ import com.daggle.animory.domain.pet.entity.*;
 import com.daggle.animory.domain.shelter.entity.Shelter;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -89,8 +90,7 @@ public class PetFixture {
                     .weight(5.0f)
                     .description("멍멍이는 귀여워요" + i)
                     .sex(Sex.MALE)
-                    .protectionExpirationDate(LocalDate.of(2023, (int) (Math.random() * 11) + 1,
-                                                           (int) (Math.random() * 30) + 1))
+                    .protectionExpirationDate(generateRandomDate())
                     .vaccinationStatus("접종완료" + i)
                     .neutralizationStatus(NeutralizationStatus.UNKNOWN)
                     .adoptionStatus(AdoptionStatus.NO)
@@ -152,5 +152,13 @@ public class PetFixture {
             );
         }
         return pets;
+    }
+
+    private static LocalDate generateRandomDate() {
+        int year = 2023;
+        int month = (int) (Math.random() * 12) + 1;
+        int day = (int) (Math.random() * YearMonth.of(year, month).lengthOfMonth()) + 1;
+
+        return LocalDate.of(year, month, day);
     }
 }


### PR DESCRIPTION
## 작업 내용
- [실수] Production Profile에 누락되어 있던 Pageable 입력 값을 기본 1로 잡아주는 설정을 추가했습니다.

- [실수] PetAge 변환 시 year가 0인 경우에 대한 테스트 동작 변경이 누락되어 있어서 추가했습니다.(Autoparams의 테스트 데이터 랜덤생성으로 우연히 얻어걸렸는데, 애초에 테스트 케이스를 확실하게 넣어뒀어야 해서 안좋은건지 아니면 예상하지 못했던 테스트케이스가 발생해서 잡아냈기 때문에 좋은건지 모르겠네요)

- **[중요]** `@PageableDefault` 에서 기본값을 1로 잡아주면, `spring.data.web.pageable.one-indexed-parameters: true` 설정과 충돌하게 되네요. 기본(no-parameter)입력으로 요청 시 page가 2가 됩니다. 따라서 0으로 잡아둬야합니다. 명시적으로 1로 입력하고 요청할 시에는 그대로 1이 됩니다. 구체적인 이유는 찾아보지 않았습니다.

- [사소한 개선] ShortForm API 문서에 pageable 그대로 노출되어 있는 api 하나 수정했습니다.(#198)

- [기본기 부족] OneToMany 동작을 제대로 이해하고 fk가 들어가도록 로직을 수정했습니다. 결론적으로 `@OneToMany` 사용의 장점은 아직 크게 모르겠지만, 지금처럼 기존 테이블에서 떨어져나가 새로운 테이블로 확장되어 나가는 경우에 유지보수 비용을 크게(매우 압도적으로, 또는 비현실적인 것을 현실적으로) 줄여주는 것 같습니다.

- [깨달음] DataJpaTest를 위한 BaseClass에서 반환된 entity를 콘솔에 출력하는 로직을 중복작성하지 않으려고 모듈화 해뒀는데, 여기서 I/O Exception이 발생하기 때문에 throw를 명시해줘야 합니다. 근데 그러면 사용하는 상위 로직에서 계속 반복적으로 throw 명시해줘야 합니다. 이걸 없애려고 catch구문으로 예외를 잡은다음에 log만 찍고 그대로 먹어버렸습니다. 결과적으로 Infinite Recursion(양방향 순환참조 시) 발생하는데 놓칠 뻔 했습니다. Exception을 catch했으면 적절하게 처리한 뒤에 최소한 Runtime Exception으로 다시 던져주도록 해야겠습니다. 발생하고 있는 순환참조(test에서 console에 찍기 때문. 실제로는 dto로 변환하기 때문에 발생하지 않겠지만) 문제 해결하는 방법으로, 그냥 습관적으로 `OneToMany - ManyToOne` 관계에서 `JsonPropertyManagedReference, BackReference` 쌍으로 달아둔다고 생각하면 좋을 것 같습니다.

- **[실제 중요한 문제 해결]** N+1쿼리가 발생하든, Lazy Loading으로 Entity들을 추가로 불러와야하는 상황에 `@Transactional` 누락으로 서버에서 버그가 터졌습니다. 추가했고, short-form domain의 N+1 쿼리도 join fetch로 해결했습니다. 그냥 가능하면 `@Service`는 `@Transactional 또는 readonly`와 함께 사용하는 것이 안전한 스프링 사용습관이 되지 않을까 생각했습니다.

- ShortForm domain에서 PetRepository를 참조하고 있는데, Pet table을 참조하되, Repository는 별도로 사용하도록 분리했습니다. 결국 마지막에는 의존성 흐름이 DB에서 만나게 되지만, 도메인 분리의 중요한 점이 "Application Code"를 독립적으로 분리하여 확장해나갈 수 있다는 목적으로 보자면 이 쪽이 좋은 practice 인 것 같습니다.

---

### 아직 해결하지 못한 것
- production서버는 root레벨에서 모든 log를 파일에 기록하도록 되어있으나, 어째서 인지 `[ExceptionHandlerExceptionResolver] Resolved [org.hibernate.LazyInitializationException: ...` 가 로그파일에 기록되지 않았습니다. 추가로 알아보겠습니다.

- `Acceptancetest - ShortFormTest`에서 query log가 제대로 안 찍히는 것 같습니다.(추측) N+1 쿼리를 해결하기 위해서, 테스트 로그로는 확인이 안되서 운영서버에 붙여서 해결했습니다. 이 부분도 더 알아보겠습니다.



Close #198 ,
Close #207 