### PR TITLE
숏폼 영상 조회 플로우에 Like 지표를 이용한 조회 기준 적용, 기존 API 응답에 Like값 추가

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/exception/handler/GlobalExceptionHandler.java
+++ b/animory/src/main/java/com/daggle/animory/common/exception/handler/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import com.daggle.animory.domain.shelter.exception.ShelterPermissionDeniedExcept
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +35,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 import javax.servlet.ServletException;
 import javax.validation.ConstraintViolationException;
 
-
+@Slf4j
 @RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -42,55 +43,68 @@ public class GlobalExceptionHandler {
     // BAD REQUEST 400
     @ExceptionHandler({AlreadyExistEmailException.class})
     public ResponseEntity<Response<Void>> handleAlreadyExistEmailException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
+
     @ExceptionHandler({CheckEmailOrPasswordException.class})
     public ResponseEntity<Response<Void>> handleCheckEmailOrPasswordException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler({InvalidFileTypeException.class})
     public ResponseEntity<Response<Void>> handleInvalidFileTypeException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler({InvalidImageTypeException.class})
     public ResponseEntity<Response<Void>> handleInvalidImageTypeException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler({InvalidVideoTypeException.class})
     public ResponseEntity<Response<Void>> handleInvalidVideoTypeException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler({NotFoundImageException.class})
     public ResponseEntity<Response<Void>> handleNotFoundImageException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler({NotFoundVideoException.class})
     public ResponseEntity<Response<Void>> handleNotFoundVideoException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler({InvalidPetAgeFormatException.class})
     public ResponseEntity<Response<Void>> handleInvalidPetAgeTypeException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler({InvalidPetYearRangeException.class})
     public ResponseEntity<Response<Void>> handleInvalidPetYearRangeException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler({InvalidPetMonthRangeException.class})
     public ResponseEntity<Response<Void>> handleInvalidPetMonthRangeException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
+
     @ExceptionHandler({ShelterAlreadyExistException.class})
     public ResponseEntity<Response<Void>> handleShelterAlreadyExistException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     // 403
@@ -109,6 +123,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Response<Void>> handlePetNotFoundException(final Exception e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Response.error(e.getMessage(), HttpStatus.NOT_FOUND));
     }
+
     @ExceptionHandler({ShelterNotFoundException.class})
     public ResponseEntity<Response<Void>> handleShelterNotFoundException(final Exception e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Response.error(e.getMessage(), HttpStatus.NOT_FOUND));
@@ -116,7 +131,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({MaxUploadSizeExceededException.class})
     public ResponseEntity<Response<Void>> handleMaxUploadSizeExceededException(final RuntimeException e) {
-        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(Response.error(e.getMessage(), HttpStatus.PAYLOAD_TOO_LARGE));
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(Response.error(e.getMessage(),
+                                                                                       HttpStatus.PAYLOAD_TOO_LARGE));
     }
 
     // INTERNAL SERVER ERROR 500
@@ -124,23 +140,27 @@ public class GlobalExceptionHandler {
     @ApiResponse(responseCode = "500", description = "예상하지 못한 서버 오류", content = @Content)
     @ExceptionHandler({Exception.class})
     public ResponseEntity<Response<Void>> internalServerError(final Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Response.error(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR));
+        log.error("Internal Server Error", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Response.error(e.getMessage(),
+                                                                                           HttpStatus.INTERNAL_SERVER_ERROR));
     }
 
     @ExceptionHandler({AmazonS3SaveError.class})
     public ResponseEntity<Response<Void>> handleAmazonS3SaveException(final Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Response.error(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Response.error(e.getMessage(),
+                                                                                           HttpStatus.INTERNAL_SERVER_ERROR));
     }
 
     @ExceptionHandler({
-            MethodArgumentTypeMismatchException.class,
-            HttpMessageNotReadableException.class,
-            IllegalArgumentException.class,
+        MethodArgumentTypeMismatchException.class,
+        HttpMessageNotReadableException.class,
+        IllegalArgumentException.class,
 
-            ConstraintViolationException.class
+        ConstraintViolationException.class
     })
     public ResponseEntity<Response<Void>> badRequest(final RuntimeException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class})
@@ -149,11 +169,12 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler({
-            HttpRequestMethodNotSupportedException.class,
-            MissingRequestValueException.class
+        HttpRequestMethodNotSupportedException.class,
+        MissingRequestValueException.class
     })
     public ResponseEntity<Response<Void>> badRequest(final ServletException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(), HttpStatus.BAD_REQUEST));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
+                                                                                 HttpStatus.BAD_REQUEST));
     }
 
     @ExceptionHandler(BindException.class)

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetVideo.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetVideo.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.domain.pet.entity;
 
+import com.daggle.animory.common.entity.BaseEntity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.*;
 
@@ -11,7 +12,7 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 @Table(name = "pet_video")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PetVideo {
+public class PetVideo extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetVideo.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/entity/PetVideo.java
@@ -2,14 +2,16 @@ package com.daggle.animory.domain.pet.entity;
 
 import com.daggle.animory.common.entity.BaseEntity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 @Getter
 @Entity
-@AllArgsConstructor
 @Table(name = "pet_video")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PetVideo extends BaseEntity {

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/ShortFormService.java
@@ -1,5 +1,6 @@
 package com.daggle.animory.domain.shortform;
 
+import com.daggle.animory.domain.pet.entity.PetVideo;
 import com.daggle.animory.domain.shortform.dto.request.ShortFormSearchCondition;
 import com.daggle.animory.domain.shortform.dto.response.CategoryShortFormPage;
 import com.daggle.animory.domain.shortform.dto.response.HomeShortFormPage;
@@ -7,8 +8,13 @@ import com.daggle.animory.domain.shortform.repository.PetVideoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -18,25 +24,37 @@ public class ShortFormService {
 
     private final PetVideoRepository petVideoRepository;
 
+    public HomeShortFormPage getHomeShortFormPage(final Pageable pageable) {
+        // LikeCount DESC 순서로 조회하고, 반환된 페이지(Slice)를 랜덤으로 섞는다.
+        Slice<PetVideo> petVideoSlice = petVideoRepository.findSliceBy(pageable);
+
+        return HomeShortFormPage.of(
+            shuffleVideos(petVideoSlice),
+            petVideoSlice.hasNext()
+        );
+    }
+
     public CategoryShortFormPage getCategoryShortFormPage(final ShortFormSearchCondition searchCondition,
                                                           final Pageable pageable) {
+        Slice<PetVideo> petVideoSlice = petVideoRepository.findSliceBy(
+            searchCondition.type(),
+            searchCondition.area(),
+            pageable
+        );
+
         return CategoryShortFormPage.of(
             buildCategoryPageTitle(searchCondition),
-            petVideoRepository.findSliceBy(
-                searchCondition.type(),
-                searchCondition.area(),
-                pageable
-            )
+            shuffleVideos(petVideoSlice),
+            petVideoSlice.hasNext()
         );
     }
 
-    public HomeShortFormPage getHomeShortFormPage(final Pageable pageable) {
-        // TODO: 홈 화면 숏폼 영상은 어떤 순서, 어떤 기준으로 보여줄 것인가?
-        return HomeShortFormPage.of(
-            petVideoRepository.findSliceBy(pageable) // TODO: 하드코딩된 Page 숫자
-        );
+    // 랜덤으로 섞는다.
+    private List<PetVideo> shuffleVideos(final Slice<PetVideo> petVideoSlice) {
+        List<PetVideo> petVideos = new ArrayList<>(petVideoSlice.getContent());
+        Collections.shuffle(petVideos);
+        return petVideos;
     }
-
 
     private String buildCategoryPageTitle(final ShortFormSearchCondition searchCondition) {
         return searchCondition.area().getProvinceNameForUI() + " 기준 " + searchCondition.type().getKoreanName() + " 친구들";

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/dto/response/CategoryShortFormPage.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/dto/response/CategoryShortFormPage.java
@@ -1,7 +1,6 @@
 package com.daggle.animory.domain.shortform.dto.response;
 
-import com.daggle.animory.domain.pet.entity.Pet;
-import org.springframework.data.domain.Slice;
+import com.daggle.animory.domain.pet.entity.PetVideo;
 
 import java.util.List;
 
@@ -13,11 +12,14 @@ public record CategoryShortFormPage(
 ) {
 
     public static CategoryShortFormPage of(final String categoryTitle,
-                                           final Slice<Pet> petSlice) {
+                                           final List<PetVideo> petVideos,
+                                           final boolean hasNext) {
         return new CategoryShortFormPage(
             categoryTitle,
-            petSlice.getContent().stream().map(ShortFormDto::of).toList(),
-            petSlice.hasNext()
+            petVideos.stream()
+                .map(ShortFormDto::of)
+                .toList(),
+            hasNext
         );
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/dto/response/HomeShortFormPage.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/dto/response/HomeShortFormPage.java
@@ -1,19 +1,21 @@
 package com.daggle.animory.domain.shortform.dto.response;
 
-import com.daggle.animory.domain.pet.entity.Pet;
-import org.springframework.data.domain.Slice;
+import com.daggle.animory.domain.pet.entity.PetVideo;
 
 import java.util.List;
 
-public record HomeShortFormPage (
+public record HomeShortFormPage(
     List<ShortFormDto> shortForms,
     boolean hasNext
-){
+) {
 
-    public static HomeShortFormPage of(final Slice<Pet> petSlice) {
+    public static HomeShortFormPage of(final List<PetVideo> petVideos,
+                                       final boolean hasNext) {
         return new HomeShortFormPage(
-            petSlice.getContent().stream().map(ShortFormDto::of).toList(),
-            petSlice.hasNext()
+            petVideos.stream()
+                .map(ShortFormDto::of)
+                .toList(),
+            hasNext
         );
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/dto/response/ShortFormDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/dto/response/ShortFormDto.java
@@ -1,6 +1,7 @@
 package com.daggle.animory.domain.shortform.dto.response;
 
 import com.daggle.animory.domain.pet.entity.Pet;
+import com.daggle.animory.domain.pet.entity.PetVideo;
 import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
 import com.daggle.animory.domain.shortform.util.LikeCountToStringConverter;
 import lombok.Builder;
@@ -17,7 +18,9 @@ public record ShortFormDto(
     String adoptionStatus
 
 ) {
-    public static ShortFormDto of(final Pet pet) {
+    public static ShortFormDto of(final PetVideo petVideo) {
+        final Pet pet = petVideo.getPet();
+
         return ShortFormDto.builder()
             .petId(pet.getId())
             .name(pet.getName())

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/dto/response/ShortFormDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/dto/response/ShortFormDto.java
@@ -2,6 +2,7 @@ package com.daggle.animory.domain.shortform.dto.response;
 
 import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.util.PetAgeToBirthDateConverter;
+import com.daggle.animory.domain.shortform.util.LikeCountToStringConverter;
 import lombok.Builder;
 
 @Builder
@@ -12,6 +13,7 @@ public record ShortFormDto(
     Integer shelterId,
     String shelterName,
     String profileShortFormUrl,
+    String likeCount,
     String adoptionStatus
 
 ) {
@@ -23,6 +25,7 @@ public record ShortFormDto(
             .shelterId(pet.getShelter().getId())
             .shelterName(pet.getShelter().getName())
             .profileShortFormUrl(pet.getPetVideo().getVideoUrl())
+            .likeCount(LikeCountToStringConverter.convert(pet.getPetVideo().getLikeCount()))
             .adoptionStatus(pet.getAdoptionStatus().getMessage())
             .build();
     }

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/repository/PetVideoRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/repository/PetVideoRepository.java
@@ -1,25 +1,32 @@
 package com.daggle.animory.domain.shortform.repository;
 
-import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.pet.entity.PetVideo;
 import com.daggle.animory.domain.shelter.entity.Province;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface PetVideoRepository extends JpaRepository<Pet, Integer> {
-    @Query("select p " +
-        "from Pet p " +
-        "join fetch p.shelter s " +
-        "join fetch p.petVideos pv ")
-    Slice<Pet> findSliceBy(Pageable pageable);
+public interface PetVideoRepository extends JpaRepository<PetVideo, Integer> {
 
-    @Query("select p " +
-        "from Pet p " +
-        "join fetch p.shelter s " +
-        "join fetch p.petVideos pv " +
-        "where s.address.province = :province " +
-        "and p.type = :petType")
-    Slice<Pet> findSliceBy(PetType petType, Province province, Pageable searchCondition);
+    @Query("""
+        select pv
+        from PetVideo pv
+        left join fetch pv.pet p
+        left join fetch p.shelter s
+        order by pv.likeCount desc
+        """)
+    Slice<PetVideo> findSliceBy(Pageable pageable);
+
+    @Query("""
+        select pv
+        from PetVideo pv
+        left join fetch pv.pet p
+        left join fetch p.shelter s
+        where s.address.province = :province
+        and p.type = :petType
+        order by pv.likeCount desc
+        """)
+    Slice<PetVideo> findSliceBy(PetType petType, Province province, Pageable searchCondition);
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shortform/util/LikeCountToStringConverter.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/util/LikeCountToStringConverter.java
@@ -1,0 +1,11 @@
+package com.daggle.animory.domain.shortform.util;
+
+public final class LikeCountToStringConverter {
+    private LikeCountToStringConverter() {}
+
+    public static String convert(final Integer likeCount) {
+        if (likeCount < 1000) return String.valueOf(likeCount);
+        else if (likeCount < 10000) return String.format("%.1f", likeCount / 1000.0) + "천";
+        else return String.format("%.1f", likeCount / 10000.0) + "만";
+    }
+}

--- a/animory/src/main/resources/db/migration/V3.1.0__add_created_updated_datetime_petvideo.sql
+++ b/animory/src/main/resources/db/migration/V3.1.0__add_created_updated_datetime_petvideo.sql
@@ -1,0 +1,5 @@
+ALTER TABLE pet_video
+    ADD created_at datetime NULL;
+
+ALTER TABLE pet_video
+    ADD updated_at datetime NULL;

--- a/animory/src/test/java/com/daggle/animory/acceptance/ShortFormTest.java
+++ b/animory/src/test/java/com/daggle/animory/acceptance/ShortFormTest.java
@@ -23,16 +23,14 @@ class ShortFormTest extends AcceptanceTest {
                         .param("page", "0"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.response.shortForms[0].petId").value(1))
-            .andExpect(jsonPath("$.response.shortForms[0].name").value("멍멍이"))
-            .andExpect(jsonPath("$.response.shortForms[0].age").value("6개월"))
-            .andExpect(jsonPath("$.response.shortForms[0].shelterId").value(1))
-            .andExpect(jsonPath("$.response.shortForms[0].shelterName").value("광주광역시동물보호소"))
-            .andExpect(jsonPath("$.response.shortForms[0].profileShortFormUrl").value("http://amazon" +
-                                                                                      ".server/api/petVideo" +
-                                                                                      "/20231001104521_test1.mp4"))
+            .andExpect(jsonPath("$.response.shortForms[0].petId").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].name").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].age").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].shelterId").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].shelterName").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].profileShortFormUrl").isNotEmpty())
             .andExpect(jsonPath("$.response.shortForms[0].likeCount").isNotEmpty())
-            .andExpect(jsonPath("$.response.shortForms[0].adoptionStatus").value("미입양"))
+            .andExpect(jsonPath("$.response.shortForms[0].adoptionStatus").isNotEmpty())
             .andExpect(jsonPath("$.response.hasNext").value(true))
             .andDo(print());
     }
@@ -52,16 +50,14 @@ class ShortFormTest extends AcceptanceTest {
                         .param("area", "광주"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.response.categoryTitle").value("광주광역시 기준 강아지 친구들"))
-            .andExpect(jsonPath("$.response.shortForms[0].petId").value(1))
-            .andExpect(jsonPath("$.response.shortForms[0].name").value("멍멍이"))
-            .andExpect(jsonPath("$.response.shortForms[0].age").value("6개월"))
-            .andExpect(jsonPath("$.response.shortForms[0].shelterId").value(1))
-            .andExpect(jsonPath("$.response.shortForms[0].shelterName").value("광주광역시동물보호소"))
-            .andExpect(jsonPath("$.response.shortForms[0].profileShortFormUrl").value("http://amazon" +
-                                                                                      ".server/api/petVideo" +
-                                                                                      "/20231001104521_test1.mp4"))
-            .andExpect(jsonPath("$.response.shortForms[0].adoptionStatus").value("미입양"))
+            .andExpect(jsonPath("$.response.categoryTitle").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].petId").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].name").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].age").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].shelterId").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].shelterName").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].profileShortFormUrl").isNotEmpty())
+            .andExpect(jsonPath("$.response.shortForms[0].adoptionStatus").isNotEmpty())
             .andExpect(jsonPath("$.response.hasNext").value(true))
             .andDo(print());
     }

--- a/animory/src/test/java/com/daggle/animory/acceptance/ShortFormTest.java
+++ b/animory/src/test/java/com/daggle/animory/acceptance/ShortFormTest.java
@@ -29,8 +29,9 @@ class ShortFormTest extends AcceptanceTest {
             .andExpect(jsonPath("$.response.shortForms[0].shelterId").value(1))
             .andExpect(jsonPath("$.response.shortForms[0].shelterName").value("광주광역시동물보호소"))
             .andExpect(jsonPath("$.response.shortForms[0].profileShortFormUrl").value("http://amazon" +
-                                                                                          ".server/api/petVideo" +
-                                                                                          "/20231001104521_test1.mp4"))
+                                                                                      ".server/api/petVideo" +
+                                                                                      "/20231001104521_test1.mp4"))
+            .andExpect(jsonPath("$.response.shortForms[0].likeCount").isNotEmpty())
             .andExpect(jsonPath("$.response.shortForms[0].adoptionStatus").value("미입양"))
             .andExpect(jsonPath("$.response.hasNext").value(true))
             .andDo(print());
@@ -58,8 +59,8 @@ class ShortFormTest extends AcceptanceTest {
             .andExpect(jsonPath("$.response.shortForms[0].shelterId").value(1))
             .andExpect(jsonPath("$.response.shortForms[0].shelterName").value("광주광역시동물보호소"))
             .andExpect(jsonPath("$.response.shortForms[0].profileShortFormUrl").value("http://amazon" +
-                                                                                          ".server/api/petVideo" +
-                                                                                          "/20231001104521_test1.mp4"))
+                                                                                      ".server/api/petVideo" +
+                                                                                      "/20231001104521_test1.mp4"))
             .andExpect(jsonPath("$.response.shortForms[0].adoptionStatus").value("미입양"))
             .andExpect(jsonPath("$.response.hasNext").value(true))
             .andDo(print());

--- a/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterRepositoryTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shelter/ShelterRepositoryTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,7 +37,8 @@ class ShelterRepositoryTest {
         shelterRepository.save(shelter);
 
         // when
-        final List<Shelter> foundShelters = shelterRepository.findAllByKakaoLocationIdIn(List.of(123456789, 1, 2, 3, 4));
+        final List<Shelter> foundShelters = shelterRepository.findAllByKakaoLocationIdIn(List.of(123456789, 1, 2, 3,
+                                                                                                 4));
 
         // then
         assertThat(foundShelters).contains(shelter);
@@ -48,21 +48,21 @@ class ShelterRepositoryTest {
     void findByAccountEmail() {
         // given
         final Account account = Account.builder()
-                .email("aa@naver.cc")
-                .password("asd!2weW")
-                .role(AccountRole.SHELTER)
-                .build();
+            .email("aa@naver.cc")
+            .password("asd!2weW")
+            .role(AccountRole.SHELTER)
+            .build();
 
         final Shelter shelter = Shelter.builder()
-                .name("테스트 보호소")
-                .address(
-                        ShelterAddress.builder()
-                                .province(Province.광주)
-                                .kakaoLocationId(123456789)
-                                .build()
-                )
-                .account(account)
-                .build();
+            .name("테스트 보호소")
+            .address(
+                ShelterAddress.builder()
+                    .province(Province.광주)
+                    .kakaoLocationId(123456789)
+                    .build()
+            )
+            .account(account)
+            .build();
 
         accountRepository.save(account);
         shelterRepository.save(shelter);

--- a/animory/src/test/java/com/daggle/animory/domain/shortform/repository/PetVideoRepositoryOrderByTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shortform/repository/PetVideoRepositoryOrderByTest.java
@@ -1,0 +1,31 @@
+package com.daggle.animory.domain.shortform.repository;
+
+import com.daggle.animory.domain.pet.entity.PetVideo;
+import com.daggle.animory.testutil.WithTimeSupportObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@Sql("classpath:sql/PetVideoRepositoryOrderByTest.sql")
+@DataJpaTest
+@EnableJpaAuditing
+class PetVideoRepositoryOrderByTest extends WithTimeSupportObjectMapper {
+    @Autowired
+    private PetVideoRepository petVideoRepository;
+
+    @Test
+    void 홈화면_숏폼조회쿼리_테스트() {
+        Slice<PetVideo> petVideos = petVideoRepository.findSliceBy(PageRequest.of(0, 10));
+        print(petVideos);
+
+        assertThat(petVideos.getContent().get(0).getLikeCount()).isEqualTo(5000);
+    }
+}

--- a/animory/src/test/java/com/daggle/animory/domain/shortform/repository/PetVideoRepositoryTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shortform/repository/PetVideoRepositoryTest.java
@@ -1,9 +1,8 @@
-package com.daggle.animory.domain.shortform;
+package com.daggle.animory.domain.shortform.repository;
 
-import com.daggle.animory.domain.pet.entity.Pet;
 import com.daggle.animory.domain.pet.entity.PetType;
+import com.daggle.animory.domain.pet.entity.PetVideo;
 import com.daggle.animory.domain.shelter.entity.Province;
-import com.daggle.animory.domain.shortform.repository.PetVideoRepository;
 import com.daggle.animory.testutil.datajpatest.DataJpaTestWithDummyData;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,17 +11,19 @@ import org.springframework.data.domain.Slice;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ShortFormRepositoryTest extends DataJpaTestWithDummyData {
+class PetVideoRepositoryTest extends DataJpaTestWithDummyData {
 
     @Autowired
     private PetVideoRepository petVideoRepository;
 
     @Test
     void findSliceBy() {
-        final Slice<Pet> slice = petVideoRepository.findSliceBy(PetType.DOG, Province.광주, PageRequest.of(0, 10));
+        final Slice<PetVideo> slice = petVideoRepository.findSliceBy(PetType.DOG, Province.광주, PageRequest.of(0, 10));
 
         print(slice.getContent());
 
         assertThat(slice.getContent()).hasSize(10);
     }
+
+
 }

--- a/animory/src/test/java/com/daggle/animory/domain/shortform/util/LikeCountToStringConverterTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shortform/util/LikeCountToStringConverterTest.java
@@ -1,0 +1,30 @@
+package com.daggle.animory.domain.shortform.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LikeCountToStringConverterTest {
+
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+        0,0
+        1,1
+        999,999
+        1000,1.0천
+        1001,1.0천
+        1100,1.1천
+        10000,1.0만
+        10001,1.0만
+        11000,1.1만
+        12345,1.2만
+        """
+    )
+    void convert(final int likeCount, final String expected) {
+        final String actual = LikeCountToStringConverter.convert(likeCount);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/animory/src/test/resources/sql/PetVideoRepositoryOrderByTest.sql
+++ b/animory/src/test/resources/sql/PetVideoRepositoryOrderByTest.sql
@@ -1,0 +1,50 @@
+SET REFERENTIAL_INTEGRITY FALSE;
+
+SET @in_a_week = TIMESTAMPADD(DAY, -3, @now);
+SET @after_a_week = TIMESTAMPADD(DAY, -8, @now);
+
+-- 일주일 이내의 데이터 10개
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (1, 'https://video.com/video1.mp4', 1, 1, '2023-10-25 00:20:00', @in_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (2, 'https://video.com/video2.mp4', 100, 2, '2023-10-25 01:00:00', @in_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (3, 'https://video.com/video3.mp4', 30, 3, '2023-10-25 02:00:00', @in_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (4, 'https://video.com/video4.mp4', 40, 4, '2023-10-25 03:00:00', @in_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (5, 'https://video.com/video5.mp4', 5000, 5, '2023-10-25 04:00:00', @in_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (6, 'https://video.com/video6.mp4', 60, 6, '2023-10-25 05:00:00', @in_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (7, 'https://video.com/video7.mp4', 70, 7, '2023-10-25 06:00:00', @in_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (8, 'https://video.com/video8.mp4', 800, 8, '2023-10-25 07:00:00', @in_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (9, 'https://video.com/video9.mp4', 90, 9, '2023-10-25 08:00:00', @in_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (10, 'https://video.com/video10.mp4', 100, 10, '2023-10-25 09:00:00', @in_a_week);
+
+-- 일주일 이상 지난 데이터 10개
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (11, 'https://video.com/video11.mp4', 10, 11, '2023-10-25 10:00:00', @after_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (12, 'https://video.com/video12.mp4', 120, 12, '2023-10-25 11:00:00', @after_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (13, 'https://video.com/video13.mp4', 130, 13, '2023-10-25 12:00:00', @after_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (14, 'https://video.com/video14.mp4', 250, 14, '2023-10-25 13:00:00', @after_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (15, 'https://video.com/video15.mp4', 150, 15, '2023-10-25 14:00:00', @after_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (16, 'https://video.com/video16.mp4', 160, 16, '2023-10-25 15:00:00', @after_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (17, 'https://video.com/video17.mp4', 170, 17, '2023-10-25 16:00:00', @after_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (18, 'https://video.com/video18.mp4', 180, 18, '2023-10-25 17:00:00', @after_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (19, 'https://video.com/video19.mp4', 2000, 19, '2023-10-25 18:00:00', @after_a_week);
+INSERT INTO pet_video (id, video_url, like_count, pet_id, created_at, updated_at)
+VALUES (20, 'https://video.com/video20.mp4', 200, 20, '2023-10-25 19:00:00', @after_a_week);
+
+SET REFERENTIAL_INTEGRITY TRUE;


### PR DESCRIPTION
## 작업 내용
- LikeCount를 short form api 응답에 추가
  - 문자열변환(1000개가 넘어가면 1.x천개 등)
  - 테스트
- PetVideo에 BaseEntity 상속(creadted,updated time)
- PetVideo 조회에 like 지표를 추가하고 랜덤으로 섞는 로직 추가



Close #209 