### PR TITLE
ShortForm Repository의 Fetch Join과 Pagination query 분리

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/shortform/repository/PetVideoRepository.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shortform/repository/PetVideoRepository.java
@@ -8,25 +8,35 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface PetVideoRepository extends JpaRepository<PetVideo, Integer> {
 
     @Query("""
-        select pv
+        select pv.id
         from PetVideo pv
-        left join fetch pv.pet p
-        left join fetch p.shelter s
+            left join pv.pet p
+            left join p.shelter s
+        where s.address.province = :province
+            and p.type = :petType
         order by pv.likeCount desc
         """)
-    Slice<PetVideo> findSliceBy(Pageable pageable);
+    Slice<Integer> findSliceOfIds(PetType petType, Province province, Pageable pageable);
+
+    @Query("""
+        select pv.id
+        from PetVideo pv
+        order by pv.likeCount desc
+        """)
+    Slice<Integer> findSliceOfIds(Pageable pageable);
 
     @Query("""
         select pv
         from PetVideo pv
         left join fetch pv.pet p
         left join fetch p.shelter s
-        where s.address.province = :province
-        and p.type = :petType
+        where pv.id in :petVideoIds
         order by pv.likeCount desc
         """)
-    Slice<PetVideo> findSliceBy(PetType petType, Province province, Pageable searchCondition);
+    List<PetVideo> findAllByPetVideoIdIn(List<Integer> petVideoIds);
 }

--- a/animory/src/main/resources/application-production.yml
+++ b/animory/src/main/resources/application-production.yml
@@ -21,6 +21,7 @@ spring:
     hibernate.ddl-auto: validate
     properties:
       hibernate.format_sql: true
+      query.fail_on_pagination_over_collection_fetch: true
   data.web.pageable.one-indexed-parameters: true # Request로 들어오는 Pageable 의 인덱스를 1부터 시작하도록 설정합니다.
   # DB Scheme History Management
   flyway:

--- a/animory/src/main/resources/application.yml
+++ b/animory/src/main/resources/application.yml
@@ -22,6 +22,7 @@ spring:
     hibernate.ddl-auto: create
     properties:
       hibernate.format_sql: true
+      query.fail_on_pagination_over_collection_fetch: true
   flyway.enabled: false # H2 Error
   data.web.pageable.one-indexed-parameters: true # Request로 들어오는 Pageable 의 인덱스를 1부터 시작하도록 설정합니다.
 

--- a/animory/src/test/java/com/daggle/animory/domain/shortform/repository/PetVideoRepositoryOrderByTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shortform/repository/PetVideoRepositoryOrderByTest.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
@@ -23,9 +25,10 @@ class PetVideoRepositoryOrderByTest extends WithTimeSupportObjectMapper {
 
     @Test
     void 홈화면_숏폼조회쿼리_테스트() {
-        Slice<PetVideo> petVideos = petVideoRepository.findSliceBy(PageRequest.of(0, 10));
+        Slice<Integer> petVideoIds = petVideoRepository.findSliceOfIds(PageRequest.of(0, 10));
+        List<PetVideo> petVideos = petVideoRepository.findAllByPetVideoIdIn(petVideoIds.getContent());
         print(petVideos);
 
-        assertThat(petVideos.getContent().get(0).getLikeCount()).isEqualTo(5000);
+        assertThat(petVideos.get(0).getLikeCount()).isEqualTo(5000);
     }
 }

--- a/animory/src/test/java/com/daggle/animory/domain/shortform/repository/PetVideoRepositoryTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/shortform/repository/PetVideoRepositoryTest.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PetVideoRepositoryTest extends DataJpaTestWithDummyData {
@@ -18,11 +20,11 @@ class PetVideoRepositoryTest extends DataJpaTestWithDummyData {
 
     @Test
     void findSliceBy() {
-        final Slice<PetVideo> slice = petVideoRepository.findSliceBy(PetType.DOG, Province.광주, PageRequest.of(0, 10));
+        final Slice<Integer> petVideoIds = petVideoRepository.findSliceOfIds(PetType.DOG, Province.광주,
+                                                                             PageRequest.of(0, 10));
+        final List<PetVideo> petVideos = petVideoRepository.findAllByPetVideoIdIn(petVideoIds.getContent());
 
-        print(slice.getContent());
-
-        assertThat(slice.getContent()).hasSize(10);
+        assertThat(petVideos).hasSize(10);
     }
 
 


### PR DESCRIPTION
## 작업 내용
- Fetch Join과 Pageable Query를 동시에 사용할 때, JPA는 의도한 대로 동작하지  않고 모든 값을 메모리에 가져와서 Pagination을 수행한다고 합니다.(이유는 모르겠음) 이 쿼리는 서비스 진입점인 홈페이지에서 가장 많이 실행되는 쿼리이기도 하고, EC2 Free Tier의 1GB 메모리를 괴롭히고 싶지 않기도하고 warning log가 잔뜩 쌓이는 것을 지우기 위해 수정해보았습니다. native query를 사용해서 1회의 쿼리로 실행하게 할 수도 있을 것 같은데 복잡하고 관리비용이 너무 커질 것이라 생각해서 쿼리를 단순히 2개로 분할하였습니다.



Close #216 