### PR TITLE
보호소 정보 수정 페이지를 위한 우편번호 관리 추가

### DIFF
--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/request/ShelterAddressSignUpDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/request/ShelterAddressSignUpDto.java
@@ -9,18 +9,19 @@ import javax.validation.constraints.NotNull;
 
 @Builder
 public record ShelterAddressSignUpDto(
-        @NotNull(message = "광역시/도를 입력해주세요.") Province province,
-        String city,
-        @NotNull(message = "도로명을 입력해주세요.") String roadName,
-        String detail) {
+    @NotNull(message = "광역시/도를 입력해주세요.") Province province,
+    String city,
+    @NotNull(message = "도로명을 입력해주세요.") String roadName,
+    String detail) {
 
     @Hidden
-    public ShelterAddress getShelterAddress() {
+    public ShelterAddress getShelterAddress(final String zonecode) {
         return ShelterAddress.builder()
-                .province(province)
-                .city(city)
-                .roadName(roadName)
-                .detail(detail)
-                .build();
+            .province(province)
+            .city(city)
+            .roadName(roadName)
+            .detail(detail)
+            .zonecode(zonecode)
+            .build();
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/account/dto/request/ShelterSignUpDto.java
+++ b/animory/src/main/java/com/daggle/animory/domain/account/dto/request/ShelterSignUpDto.java
@@ -15,29 +15,29 @@ import javax.validation.constraints.Pattern;
 
 @Builder
 public record ShelterSignUpDto(
-        @Email(message = "이메일 형식에 맞지 않습니다.")
-        @NotBlank(message = "이메일을 입력해주세요.") String email,
-        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&+=!])(?!.*\\s).{8,20}$",
-                message = "비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호여야 합니다.") String password,
-        @NotNull(message = "보호소 이름을 입력해주세요.") String name,
-        @NotNull(message = "보호소 연락처를 입력해주세요.") String contact,
-        String zonecode,
-        @Valid @NotNull(message = "보호소 주소를 입력해주세요.") ShelterAddressSignUpDto address) {
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일을 입력해주세요.") String email,
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@#$%^&+=!])(?!.*\\s).{8,20}$",
+        message = "비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상씩 포함된 8자 ~ 20자의 비밀번호여야 합니다.") String password,
+    @NotNull(message = "보호소 이름을 입력해주세요.") String name,
+    @NotNull(message = "보호소 연락처를 입력해주세요.") String contact,
+    String zonecode,
+    @Valid @NotNull(message = "보호소 주소를 입력해주세요.") ShelterAddressSignUpDto address) {
 
     public Account getAccount(final PasswordEncoder encodePassword) {
         return Account.builder()
-                .email(email)
-                .password(encodePassword.encode(password))
-                .role(AccountRole.SHELTER)
-                .build();
+            .email(email)
+            .password(encodePassword.encode(password))
+            .role(AccountRole.SHELTER)
+            .build();
     }
 
     public Shelter getShelter(final Account account) {
         return Shelter.builder()
-                .name(name)
-                .contact(contact)
-                .address(address.getShelterAddress())
-                .account(account)
-                .build();
+            .name(name)
+            .contact(contact)
+            .address(address.getShelterAddress(zonecode))
+            .account(account)
+            .build();
     }
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/ShelterAddress.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/ShelterAddress.java
@@ -2,6 +2,7 @@ package com.daggle.animory.domain.shelter.entity;
 
 import lombok.*;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotNull;
 
@@ -28,5 +29,8 @@ public class ShelterAddress {
     private String roadName;
 
     private String detail;
+
+    @Column(length = 10, name = "zone_code")
+    private String zonecode;
 
 }

--- a/animory/src/main/resources/db/migration/V4.1.0__add_zone_code.sql
+++ b/animory/src/main/resources/db/migration/V4.1.0__add_zone_code.sql
@@ -1,0 +1,4 @@
+-- 보호소 정보 수정을 위한 기존 보호소 주소와 우편번호 조회를 위해 값이 필요하게 되었습니다.
+
+ALTER TABLE shelter
+    ADD zone_code varchar(10) NULL;

--- a/animory/src/test/java/com/daggle/animory/acceptance/AccountTest.java
+++ b/animory/src/test/java/com/daggle/animory/acceptance/AccountTest.java
@@ -26,8 +26,8 @@ class AccountTest extends AcceptanceTest {
         final EmailValidateDto emailValidateDto = new EmailValidateDto(EMAIL + "1");
 
         result = mvc.perform(post("/account/email")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(om.writeValueAsString(emailValidateDto)));
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(om.writeValueAsString(emailValidateDto)));
 
         assertSuccess();
     }
@@ -38,6 +38,7 @@ class AccountTest extends AcceptanceTest {
             .email(EMAIL + "1")
             .password(PASSWORD)
             .name("테스트 보호소")
+            .zonecode("12345")
             .address(
                 ShelterAddressSignUpDto.builder()
                     .province(Province.광주)
@@ -51,8 +52,8 @@ class AccountTest extends AcceptanceTest {
 
 
         result = mvc.perform(post("/account/shelter")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(om.writeValueAsString(shelterSignUpDto)));
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(om.writeValueAsString(shelterSignUpDto)));
 
         assertSuccess();
     }
@@ -76,8 +77,8 @@ class AccountTest extends AcceptanceTest {
 
 
         result = mvc.perform(post("/account/shelter")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(shelterSignUpDto)))
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(om.writeValueAsString(shelterSignUpDto)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.success").value(false));
     }
@@ -90,8 +91,8 @@ class AccountTest extends AcceptanceTest {
             .build();
 
         result = mvc.perform(post("/account/login")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(om.writeValueAsString(accountLoginDto)));
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(om.writeValueAsString(accountLoginDto)));
 
         assertSuccess();
         result.andExpect(jsonPath("$.response.accountId").value(1))
@@ -101,8 +102,8 @@ class AccountTest extends AcceptanceTest {
 
         // header authorization field exists
         assertThat(result.andReturn()
-            .getResponse()
-            .getHeader("Authorization")).isNotNull();
+                       .getResponse()
+                       .getHeader("Authorization")).isNotNull();
     }
 
     @Test
@@ -113,8 +114,8 @@ class AccountTest extends AcceptanceTest {
             .build();
 
         result = mvc.perform(post("/account/login")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(om.writeValueAsString(accountLoginDto)))
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(om.writeValueAsString(accountLoginDto)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.error.message").value("이메일 또는 비밀번호를 확인해주세요."));

--- a/animory/src/test/java/com/daggle/animory/acceptance/ShelterTest.java
+++ b/animory/src/test/java/com/daggle/animory/acceptance/ShelterTest.java
@@ -3,7 +3,8 @@ package com.daggle.animory.acceptance;
 import com.daggle.animory.testutil.AcceptanceTest;
 import org.junit.jupiter.api.Test;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -11,31 +12,33 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class ShelterTest extends AcceptanceTest {
 
     /**
-     근처 동물 보호소 보기 (지도 페이지)
-     입력받은 주소(kakao id)들 중 DB에 존재하는 주소(kakao id)들을 찾아서 필터링하여 응답한다.
+     * 근처 동물 보호소 보기 (지도 페이지)
+     * 입력받은 주소(kakao id)들 중 DB에 존재하는 주소(kakao id)들을 찾아서 필터링하여 응답한다.
      */
     @Test
     void 근처_동물_보호소_보기() throws Exception {
         mvc.perform(post("/shelter/filter")
-            .contentType("application/json")
-            .content("[14569757, 14569758, 14569759]"))
+                        .contentType("application/json")
+                        .content("[14569757, 14569758, 14569759]"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.response").isArray())
             .andExpect(jsonPath("$.response[0].kakaoLocationId").value(14569757));
     }
 
     /**
-     보호소 상세 페이지(프로필)
-         보호소 기본 정보(이름, 주소, 연락처)를 확인할 수 있다.
-         해당 보호소가 보호중인 동물들을 확인할 수 있다. (유기동물 프로필 리스트 페이지와 동일하게 보여진다)
-         앱에서 전화걸기를 클릭하면 전화번호가 뜬다.
+     * 보호소 상세 페이지(프로필)
+     * 보호소 기본 정보(이름, 주소, 연락처)를 확인할 수 있다.
+     * 해당 보호소가 보호중인 동물들을 확인할 수 있다. (유기동물 프로필 리스트 페이지와 동일하게 보여진다)
+     * 앱에서 전화걸기를 클릭하면 전화번호가 뜬다.
      */
     @Test
     void 보호소_상세_페이지() throws Exception {
         mvc.perform(get("/shelter/{shelterId}", 1)
-            .param("page", "0"))
+                        .param("page", "0"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.response.shelter.name").value("광주광역시동물보호소"))
+            .andExpect(jsonPath("$.response.shelter.address.province").value("광주"))
+            .andExpect(jsonPath("$.response.shelter.address.zonecode").isNotEmpty())
             .andDo(print());
     }
 }

--- a/animory/src/test/java/com/daggle/animory/testutil/fixture/ShelterFixture.java
+++ b/animory/src/test/java/com/daggle/animory/testutil/fixture/ShelterFixture.java
@@ -22,6 +22,7 @@ public class ShelterFixture {
                     .province(Province.광주)
                     .city("북구")
                     .roadName("본촌동 378-6")
+                    .zonecode("61486")
                     .build()
             )
             .account(account)


### PR DESCRIPTION
## 작업 내용
- 데이터베이스의 보호소 주소에 우편번호(zonecode)를 추가하고 기존의 API Request형식을 바꾸지 않는 선에서, 저장하는 로직을 수정하였습니다.



Close #234 