### PR TITLE
Province Enum 입력 값에 대한 유연한 처리(제주, 제주도, 제주특별자치도 등)

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/config/EnumConverterConfiguration.java
+++ b/animory/src/main/java/com/daggle/animory/common/config/EnumConverterConfiguration.java
@@ -1,0 +1,14 @@
+package com.daggle.animory.common.config;
+
+import com.daggle.animory.domain.shelter.ProvinceConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class EnumConverterConfiguration implements WebMvcConfigurer {
+    @Override
+    public void addFormatters(final FormatterRegistry registry) {
+        registry.addConverter(new ProvinceConverter());
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/ProvinceConverter.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/ProvinceConverter.java
@@ -1,0 +1,13 @@
+package com.daggle.animory.domain.shelter;
+
+
+import com.daggle.animory.domain.shelter.entity.Province;
+import org.springframework.core.convert.converter.Converter;
+
+public class ProvinceConverter implements Converter<String, Province> {
+
+    @Override
+    public Province convert(final String source) {
+        return Province.fromJson(source);
+    }
+}

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Province.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Province.java
@@ -1,5 +1,8 @@
 package com.daggle.animory.domain.shelter.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public enum Province {
     서울,
     부산,
@@ -8,15 +11,41 @@ public enum Province {
     광주,
     대전,
     울산,
-    세종특별자치시,
+    세종,
     경기,
-    강원특별자치도,
+    강원,
     충북,
     충남,
     전북,
     전남,
     경북,
     경남,
-    제주특별자치도;
+    제주;
+
+    @JsonCreator
+    public static Province fromJson(@JsonProperty("province") final String province) {
+        return switch (province) {
+            case "서울특별시", "서울시", "서울" -> 서울;
+            case "부산광역시", "부산시", "부산" -> 부산;
+            case "대구광역시", "대구시", "대구" -> 대구;
+            case "인천광역시", "인천시", "인천" -> 인천;
+            case "광주광역시", "광주시", "광주" -> 광주;
+            case "대전광역시", "대전시", "대전" -> 대전;
+            case "울산광역시", "울산시", "울산" -> 울산;
+            case "세종특별자치시", "세종시", "세종" -> 세종;
+            case "경기도", "경기" -> 경기;
+            case "강원특별자치도", "강원도", "강원" -> 강원;
+            case "충청북도", "충북" -> 충북;
+            case "충청남도", "충남" -> 충남;
+            case "전라북도", "전북" -> 전북;
+            case "전라남도", "전남" -> 전남;
+            case "경상북도", "경북" -> 경북;
+            case "경상남도", "경남" -> 경남;
+            case "제주특별자치도", "제주도", "제주" -> 제주;
+
+            default -> throw new IllegalArgumentException("Unknown Province value: " + province);
+        };
+    }
+
 
 }

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Province.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/Province.java
@@ -2,7 +2,9 @@ package com.daggle.animory.domain.shelter.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public enum Province {
     서울,
     부산,
@@ -22,8 +24,10 @@ public enum Province {
     경남,
     제주;
 
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    // Mode.DELEGATING에 대해서 자세히 이해 못함: https://github.com/FasterXML/jackson-module-kotlin/issues/336
     public static Province fromJson(@JsonProperty("province") final String province) {
+        log.debug("Province fromJson: {} ", province);
         return switch (province) {
             case "서울특별시", "서울시", "서울" -> 서울;
             case "부산광역시", "부산시", "부산" -> 부산;

--- a/animory/src/main/java/com/daggle/animory/domain/shelter/entity/ShelterAddress.java
+++ b/animory/src/main/java/com/daggle/animory/domain/shelter/entity/ShelterAddress.java
@@ -4,6 +4,8 @@ import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
 
 @Getter
@@ -22,6 +24,7 @@ public class ShelterAddress {
     private double y;
 
     @NotNull
+    @Enumerated(EnumType.STRING)
     private Province province;
 
     private String city;

--- a/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
+++ b/animory/src/test/java/com/daggle/animory/domain/account/AccountControllerTest.java
@@ -7,6 +7,7 @@ import com.daggle.animory.domain.account.dto.request.ShelterAddressSignUpDto;
 import com.daggle.animory.domain.account.dto.request.ShelterSignUpDto;
 import com.daggle.animory.domain.shelter.entity.Province;
 import com.daggle.animory.testutil.webmvctest.BaseWebMvcTest;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Slf4j
 @Import(AccountController.class)
 public class AccountControllerTest extends BaseWebMvcTest {
 
@@ -30,121 +32,123 @@ public class AccountControllerTest extends BaseWebMvcTest {
         void 성공_보호소_회원가입() throws Exception {
             // given
             final ShelterSignUpDto shelterSignUpDto = ShelterSignUpDto.builder()
-                    .name("animory")
-                    .email("aaa@jnu.ac.kr")
-                    .password("secreT123!")
-                    .contact("01012345678")
-                    .zonecode("3143")
-                    .address(ShelterAddressSignUpDto.builder()
-                            .province(Province.광주)
-                            .city("북구")
-                            .roadName("용봉동")
-                            .detail("전남대")
-                            .build())
-                    .build();
+                .name("animory")
+                .email("aaa@jnu.ac.kr")
+                .password("secreT123!")
+                .contact("01012345678")
+                .zonecode("3143")
+                .address(ShelterAddressSignUpDto.builder()
+                             .province(Province.광주)
+                             .city("북구")
+                             .roadName("용봉동")
+                             .detail("전남대")
+                             .build())
+                .build();
+
+            log.debug("shelterSignUpDto: {}", om.writeValueAsString(shelterSignUpDto));
 
             mvc.perform(post("/account/shelter")
                             .content(om.writeValueAsString(shelterSignUpDto))
                             .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andDo(print());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(print());
         }
 
         @Test
         void 실패_이메일_형식_오류() throws Exception {
             // given
             final ShelterSignUpDto shelterSignUpDto = ShelterSignUpDto.builder()
-                    .name("animory")
-                    .email("aaajnu.ac.kr")
-                    .password("secreR123!")
-                    .contact("01012345678")
-                    .zonecode("3143")
-                    .address(ShelterAddressSignUpDto.builder()
-                            .province(Province.광주)
-                            .city("북구")
-                            .roadName("용봉동")
-                            .detail("전남대")
-                            .build())
-                    .build();
+                .name("animory")
+                .email("aaajnu.ac.kr")
+                .password("secreR123!")
+                .contact("01012345678")
+                .zonecode("3143")
+                .address(ShelterAddressSignUpDto.builder()
+                             .province(Province.광주)
+                             .city("북구")
+                             .roadName("용봉동")
+                             .detail("전남대")
+                             .build())
+                .build();
 
             mvc.perform(post("/account/shelter")
                             .content(om.writeValueAsString(shelterSignUpDto))
                             .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andDo(print());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andDo(print());
         }
 
         @Test
         void 실패_비밀번호_형식_오류() throws Exception {
             // given
             final ShelterSignUpDto shelterSignUpDto = ShelterSignUpDto.builder()
-                    .name("animory")
-                    .email("aaa@jnu.ac.kr")
-                    .password("secre123!")
-                    .contact("01012345678")
-                    .zonecode("3143")
-                    .address(ShelterAddressSignUpDto.builder()
-                            .province(Province.광주)
-                            .city("북구")
-                            .roadName("용봉동")
-                            .detail("전남대")
-                            .build())
-                    .build();
+                .name("animory")
+                .email("aaa@jnu.ac.kr")
+                .password("secre123!")
+                .contact("01012345678")
+                .zonecode("3143")
+                .address(ShelterAddressSignUpDto.builder()
+                             .province(Province.광주)
+                             .city("북구")
+                             .roadName("용봉동")
+                             .detail("전남대")
+                             .build())
+                .build();
 
             mvc.perform(post("/account/shelter")
                             .content(om.writeValueAsString(shelterSignUpDto))
                             .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andDo(print());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andDo(print());
         }
 
         @Test
         void 실패_보호소_회원가입_주소null() throws Exception {
             // given
             final ShelterSignUpDto shelterSignUpDto = ShelterSignUpDto.builder()
-                    .name("animory")
-                    .email("aaa@jnu.ac.kr")
-                    .password("secreT123!")
-                    .contact("01012345678")
-                    .zonecode("3143")
-                    .address(null)
-                    .build();
+                .name("animory")
+                .email("aaa@jnu.ac.kr")
+                .password("secreT123!")
+                .contact("01012345678")
+                .zonecode("3143")
+                .address(null)
+                .build();
 
             mvc.perform(post("/account/shelter")
                             .content(om.writeValueAsString(shelterSignUpDto))
                             .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andExpect(jsonPath("$.error.message").value("보호소 주소를 입력해주세요."))
-                    .andDo(print());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.message").value("보호소 주소를 입력해주세요."))
+                .andDo(print());
         }
 
         @Test
         void 실패_보호소_회원가입_주소_중_일부null() throws Exception {
             // given
             final ShelterSignUpDto shelterSignUpDto = ShelterSignUpDto.builder()
-                    .name("animory")
-                    .email("aaa@jnu.ac.kr")
-                    .password("secreT123!")
-                    .contact("01012345678")
-                    .zonecode("3143")
-                    .address(ShelterAddressSignUpDto.builder()
-                            .province(null)
-                            .city(null) // city는 null 허용
-                            .roadName("용봉동")
-                            .detail("전남대")
-                            .build())
-                    .build();
+                .name("animory")
+                .email("aaa@jnu.ac.kr")
+                .password("secreT123!")
+                .contact("01012345678")
+                .zonecode("3143")
+                .address(ShelterAddressSignUpDto.builder()
+                             .province(null)
+                             .city(null) // city는 null 허용
+                             .roadName("용봉동")
+                             .detail("전남대")
+                             .build())
+                .build();
 
             mvc.perform(post("/account/shelter")
                             .content(om.writeValueAsString(shelterSignUpDto))
                             .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andDo(print());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andDo(print());
         }
     }
 
@@ -154,47 +158,48 @@ public class AccountControllerTest extends BaseWebMvcTest {
         void 성공_로그인() throws Exception {
             // given
             final AccountLoginDto accountLoginDto = AccountLoginDto.builder()
-                    .email("aaa@naver.com")
-                    .password("asdfA123!")
-                    .build();
+                .email("aaa@naver.com")
+                .password("asdfA123!")
+                .build();
 
 
             mvc.perform(post("/account/login")
                             .content(om.writeValueAsString(accountLoginDto))
                             .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andDo(print());
+                .andExpect(status().isOk())
+                .andDo(print());
         }
 
         @Test
         void 실패_이메일_널이면_안된다() throws Exception {
             // given
             final AccountLoginDto accountLoginDto = AccountLoginDto.builder()
-                    .email(null)
-                    .password("asdfA123")
-                    .build();
+                .email(null)
+                .password("asdfA123")
+                .build();
 
             mvc.perform(post("/account/login")
                             .content(om.writeValueAsString(accountLoginDto))
                             .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andDo(print());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andDo(print());
         }
+
         @Test
         void 실패_비밀번호_널이면_안된다() throws Exception {
             // given
             final AccountLoginDto accountLoginDto = AccountLoginDto.builder()
-                    .email("dsfdf@dfa.com")
-                    .password(null)
-                    .build();
+                .email("dsfdf@dfa.com")
+                .password(null)
+                .build();
 
             mvc.perform(post("/account/login")
                             .content(om.writeValueAsString(accountLoginDto))
                             .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.success").value(false))
-                    .andDo(print());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andDo(print());
         }
     }
 
@@ -208,9 +213,9 @@ public class AccountControllerTest extends BaseWebMvcTest {
             mvc.perform(post("/account/email")
                             .content(om.writeValueAsString(emailValidateDto))
                             .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andDo(print());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andDo(print());
         }
     }
 }


### PR DESCRIPTION
## 작업 내용
- Jackson의 `@JsonCreator`와 Converter 를 사용해서 처리했습니다.
- DB에서 Province가 integer 타입으로 관리되고 있어서 `@Enumetrated String` 설정 추가했습니다(기존 데이터도 모두 변경)




Close #240 ,
Close #241 