### PR TITLE
Security Exception Handling에서 응답이 제대로 나오도록 처리

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/exception/handler/GlobalExceptionHandler.java
+++ b/animory/src/main/java/com/daggle/animory/common/exception/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.daggle.animory.common.exception.handler;
 
 import com.daggle.animory.common.Response;
 import com.daggle.animory.common.security.exception.ForbiddenException;
+import com.daggle.animory.common.security.exception.UnAuthorizedException;
 import com.daggle.animory.domain.account.exception.AlreadyExistEmailException;
 import com.daggle.animory.domain.account.exception.CheckEmailOrPasswordException;
 import com.daggle.animory.domain.fileserver.exception.*;
@@ -106,6 +107,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(e.getMessage(),
                                                                                  HttpStatus.BAD_REQUEST));
     }
+
+    // 401
+    @ExceptionHandler({UnAuthorizedException.class})
+    public ResponseEntity<Response<Void>> handleUnAuthorizedException(final Exception e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Response.error(e.getMessage(),
+                                                                                  HttpStatus.UNAUTHORIZED));
+    }
+
 
     // 403
     @ExceptionHandler({ShelterPermissionDeniedException.class})

--- a/animory/src/main/java/com/daggle/animory/common/security/SecurityConfig.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.daggle.animory.common.security;
 
 import com.daggle.animory.common.security.exception.ForbiddenException;
 import com.daggle.animory.common.security.exception.JwtExceptionFilter;
+import com.daggle.animory.common.security.exception.UnAuthorizedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,8 +21,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.HandlerExceptionResolver;
-
-import javax.servlet.http.HttpServletResponse;
 
 @Slf4j
 @Configuration
@@ -64,12 +63,12 @@ public class SecurityConfig {
         http.apply(new SecurityFilterManagerImpl());
 
         http.exceptionHandling().authenticationEntryPoint((request, response, authException) -> {
-            log.info(authException.getMessage());
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            log.info("{}, {}", request.getRemoteAddr(), authException.getMessage());
+            resolver.resolveException(request, response, null, new UnAuthorizedException());
         });
 
         http.exceptionHandling().accessDeniedHandler((request, response, accessDeniedException) -> {
-            log.info(accessDeniedException.getMessage());
+            log.info("{}, {}", request.getRemoteAddr(), accessDeniedException.getMessage());
             resolver.resolveException(request, response, null, new ForbiddenException());
         });
 

--- a/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/TokenProvider.java
@@ -17,12 +17,11 @@ import java.util.Date;
 @Component
 public class TokenProvider {
 
-    private final String key;
     private static final String TOKEN_PREFIX = "Bearer ";
     private static final String ROLES_CLAIM = "roles";
-
     private static final int TOKEN_EXPIRATION_DATE_TO_PLUS = 1;
     private static final int TOKEN_EXPIRATION_FIXED_HOUR = 3;
+    private final String key;
 
     public TokenProvider(@Value("${jwt.secret}") final String key) {
         this.key = Base64.getEncoder().encodeToString(key.getBytes());
@@ -31,13 +30,14 @@ public class TokenProvider {
 
     public String create(final String email, final AccountRole role) {
         return TOKEN_PREFIX + Jwts.builder().setSubject(email) // 정보 저장
-                .claim(ROLES_CLAIM, role).setIssuedAt(new Date()) // 토큰 발행 시간
-                .setExpiration(calcExpirationDateTime()) // 토큰 만료 시간
-                .signWith(SignatureAlgorithm.HS256, key)  // 암호화 알고리즘 및 secretKey
-                .compact();
+            .claim(ROLES_CLAIM, role).setIssuedAt(new Date()) // 토큰 발행 시간
+            .setExpiration(calcExpirationDateTime()) // 토큰 만료 시간
+            .signWith(SignatureAlgorithm.HS256, key)  // 암호화 알고리즘 및 secretKey
+            .compact();
     }
 
-    public TokenWithExpirationDateTimeDto createTokenWithExpirationDateTimeDto(final String email, final AccountRole role) {
+    public TokenWithExpirationDateTimeDto createTokenWithExpirationDateTimeDto(final String email,
+                                                                               final AccountRole role) {
         final Date expirationDateTime = calcExpirationDateTime();
         final String token = TOKEN_PREFIX + Jwts.builder().setSubject(email)
             .claim(ROLES_CLAIM, role).setIssuedAt(new Date())
@@ -70,17 +70,17 @@ public class TokenProvider {
 
     private Claims extractBody(final String token) {
         return Jwts.parser()
-                .setSigningKey(key)
-                .parseClaimsJws(token)
-                .getBody();
+            .setSigningKey(key)
+            .parseClaimsJws(token)
+            .getBody();
     }
 
     private Date calcExpirationDateTime() {
         final LocalDateTime currentTime = LocalDateTime.now(); // 현재 시각으로 부터
 
         final LocalDateTime expirationDateTime = currentTime
-                .plusDays(TOKEN_EXPIRATION_DATE_TO_PLUS) // day를 더하고
-                .withHour(TOKEN_EXPIRATION_FIXED_HOUR); // 고정된 시각
+            .plusDays(TOKEN_EXPIRATION_DATE_TO_PLUS) // day를 더하고
+            .withHour(TOKEN_EXPIRATION_FIXED_HOUR); // 고정된 시각
 
         return convertLocalDateTimeToDate(expirationDateTime);
     }

--- a/animory/src/main/java/com/daggle/animory/common/security/exception/JwtExceptionFilter.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/exception/JwtExceptionFilter.java
@@ -1,11 +1,12 @@
 package com.daggle.animory.common.security.exception;
 
+import com.daggle.animory.common.Response;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.JwtException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
-import com.daggle.animory.common.Response;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -13,9 +14,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Slf4j
 public class JwtExceptionFilter extends OncePerRequestFilter {
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,
+                                    final FilterChain filterChain) throws ServletException, IOException {
+        log.debug("JwtExceptionFilter 동작");
         try {
             filterChain.doFilter(request, response);
         } catch (final JwtException e) {
@@ -23,9 +27,9 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");
             response.getWriter().write(
-                    new ObjectMapper()
-                            .writeValueAsString(
-                                    Response.error(e.getMessage(), HttpStatus.UNAUTHORIZED)));
+                new ObjectMapper()
+                    .writeValueAsString(
+                        Response.error(e.getMessage(), HttpStatus.UNAUTHORIZED)));
         }
     }
 }

--- a/animory/src/main/java/com/daggle/animory/common/security/exception/UnAuthorizedException.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/exception/UnAuthorizedException.java
@@ -1,0 +1,9 @@
+package com.daggle.animory.common.security.exception;
+
+public class UnAuthorizedException extends RuntimeException {
+    @Override
+    public String getMessage() {
+        return SecurityExceptionMessage.UNAUTHORIZED.getMessage();
+    }
+}
+

--- a/animory/src/test/java/com/daggle/animory/acceptance/PetTest.java
+++ b/animory/src/test/java/com/daggle/animory/acceptance/PetTest.java
@@ -28,9 +28,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class PetTest extends AcceptanceTest {
 
     final MockMultipartFile image = new MockMultipartFile("profileImage", "image.jpg", "image/jpeg",
-                                                          "image" .getBytes(StandardCharsets.UTF_8));
+                                                          "image".getBytes(StandardCharsets.UTF_8));
     final MockMultipartFile video = new MockMultipartFile("profileVideo", "video.mp4", "video/mp4",
-                                                          "video" .getBytes(StandardCharsets.UTF_8));
+                                                          "video".getBytes(StandardCharsets.UTF_8));
 
     @Nested
     class 강아지_등록 {


### PR DESCRIPTION
## 작업 내용
1. 토큰이 아예 존재하지 않는 경우
2. 토큰이 존재하지만 검사를 통과하지 못하는 경우
에 각각 응답이 형식에 맞게 반환되도록 수정하였습니다.



Close #250 