### PR TITLE
프로필 목록 페이지 조회 시 프로필 긴급, 신규 각각 4개씩 전달

### DIFF
--- a/animory/src/main/java/com/daggle/animory/common/security/exception/SecurityExceptionMessage.java
+++ b/animory/src/main/java/com/daggle/animory/common/security/exception/SecurityExceptionMessage.java
@@ -3,8 +3,7 @@ package com.daggle.animory.common.security.exception;
 public enum SecurityExceptionMessage {
     UNAUTHORIZED("인증되지 않은 사용자입니다."),
     FORBIDDEN("권한이 없습니다."),
-    INVALID_TOKEN("유효하지 않은 토큰입니다."),
-    INVALID_TOKEN_FORMAT("유효하지 않은 토큰 형식입니다."),;
+    ;
 
     private final String message;
 

--- a/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
+++ b/animory/src/main/java/com/daggle/animory/domain/pet/service/PetReadService.java
@@ -25,8 +25,8 @@ public class PetReadService {
 
     public PetProfilesDto getPetProfiles() {
         // sos, new 프로필 각각 최대 8개씩 조회
-        final List<Pet> sosProfiles = petRepository.findProfilesWithProtectionExpirationDate(PageRequest.of(0, 8)).getContent();
-        final List<Pet> newProfiles = petRepository.findProfilesWithCreatedAt(PageRequest.of(0, 8)).getContent();
+        final List<Pet> sosProfiles = petRepository.findProfilesWithProtectionExpirationDate(PageRequest.of(0, 4)).getContent();
+        final List<Pet> newProfiles = petRepository.findProfilesWithCreatedAt(PageRequest.of(0, 4)).getContent();
 
         // DTO에 넣어주기
         final List<SosPetDto> sosList = sosProfiles.stream()


### PR DESCRIPTION
## 작업 내용
- 프로필 목록 페이지 조회 시 프로필 긴급, 신규 각각 4개씩 전달
- 시큐리티 패키지의 ExceptionMessage에 사용하지 않는 예외들 제거

## 기타
- 더보기로 진입하는 긴급 조회 페이지, 신규 조회 페이지의 프로필은 여전히 8개로 반환합니다!

Close #253 